### PR TITLE
Fix rational forward kin test

### DIFF
--- a/multibody/rational_forward_kinematics/BUILD.bazel
+++ b/multibody/rational_forward_kinematics/BUILD.bazel
@@ -32,6 +32,7 @@ drake_cc_package_library(
         ":generate_monomial_basis_util",
         ":plane_side",
         ":rational_forward_kinematics_core",
+        ":redundant_inequality_pruning",
     ],
 )
 
@@ -119,6 +120,11 @@ drake_cc_library(
     ],
     hdrs = [
         "configuration_space_collision_free_region.h",
+    ],
+    tags = [
+        # Don't add this library to "rational_forward_kinematics", as this
+        # library will be replaced by cspace_free_region
+        "exclude_from_package",
     ],
     deps = [
         ":convex_geometry",

--- a/multibody/rational_forward_kinematics/BUILD.bazel
+++ b/multibody/rational_forward_kinematics/BUILD.bazel
@@ -209,6 +209,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "convex_geometry_test",
+    size = "medium",
     deps = [
         ":convex_geometry",
         "//common/test_utilities:eigen_matrix_compare",

--- a/multibody/rational_forward_kinematics/configuration_space_collision_free_region.cc
+++ b/multibody/rational_forward_kinematics/configuration_space_collision_free_region.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <optional>
 
 #include "drake/multibody/rational_forward_kinematics/generate_monomial_basis_util.h"
 #include "drake/multibody/rational_forward_kinematics/rational_forward_kinematics_internal.h"
@@ -220,8 +221,8 @@ ConfigurationSpaceCollisionFreeRegion::GenerateLinkOnOneSideOfPlaneRationals(
                                                      obstacle->get_id()))
                                 ->second->a;
           Eigen::Vector3d p_AC;
-          // find the positions of the center of B (which are expressed in frameB)
-          // expressed in the frame A
+          // find the positions of the center of B (which are expressed in
+          // frameB) expressed in the frame A
           rational_forward_kinematics_.plant().CalcPointsPositions(
               *context_not_in_collision,
               rational_forward_kinematics_.plant()

--- a/multibody/rational_forward_kinematics/configuration_space_collision_free_region.h
+++ b/multibody/rational_forward_kinematics/configuration_space_collision_free_region.h
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -192,7 +193,7 @@ class ConfigurationSpaceCollisionFreeRegion {
    * <= d is collision free.
    */
   struct ConstructProgramReturn {
-    ConstructProgramReturn(size_t rationals_size)
+    explicit ConstructProgramReturn(size_t rationals_size)
         : prog{new solvers::MathematicalProgram()},
           lagrangians{rationals_size},
           verified_polynomials{rationals_size} {}

--- a/multibody/rational_forward_kinematics/cspace_free_region.cc
+++ b/multibody/rational_forward_kinematics/cspace_free_region.cc
@@ -1,6 +1,8 @@
 #include "drake/multibody/rational_forward_kinematics/cspace_free_region.h"
 
+#include <algorithm>
 #include <limits>
+#include <optional>
 
 #include <fmt/format.h>
 

--- a/multibody/rational_forward_kinematics/cspace_free_region.h
+++ b/multibody/rational_forward_kinematics/cspace_free_region.h
@@ -163,7 +163,7 @@ class CspaceFreeRegion {
    * verify the C-space region C * t <= d is collision free.
    */
   struct CspacePolytopeProgramReturn {
-    CspacePolytopeProgramReturn(size_t rationals_size)
+    explicit CspacePolytopeProgramReturn(size_t rationals_size)
         : prog{new solvers::MathematicalProgram()},
           polytope_lagrangians{rationals_size},
           t_lower_lagrangians{rationals_size},

--- a/multibody/rational_forward_kinematics/rational_forward_kinematics.h
+++ b/multibody/rational_forward_kinematics/rational_forward_kinematics.h
@@ -38,29 +38,28 @@ class RationalForwardKinematics {
 
   template <typename T>
   struct Pose {
-//    drake::Vector3<T> p_AB;
-      Eigen::Matrix<T,3,1> p_AB;
-//    drake::Matrix3<T> R_AB;
-      Eigen::Matrix<T,3,3> R_AB;
+    //    drake::Vector3<T> p_AB;
+    Eigen::Matrix<T, 3, 1> p_AB;
+    //    drake::Matrix3<T> R_AB;
+    Eigen::Matrix<T, 3, 3> R_AB;
 
     drake::multibody::BodyIndex frame_A_index;
-    int one(){
-        return 1;
-    }
-    drake::math::RigidTransform<drake::symbolic::Expression> asRigidTransformExpression() const{
-        Eigen::Matrix<drake::symbolic::Expression,3,3>  R_AB_expr;
-        R_AB_expr <<
-            R_AB.coeff(0,0).ToExpression(), R_AB.coeff(0,1).ToExpression(), R_AB.coeff(0,2).ToExpression(),
-            R_AB.coeff(1,0).ToExpression(), R_AB.coeff(1,1).ToExpression(), R_AB.coeff(1,2).ToExpression(),
-            R_AB.coeff(2,0).ToExpression(), R_AB.coeff(2,1).ToExpression(), R_AB.coeff(2,2).ToExpression()
-            ;
-        math::RotationMatrix<drake::symbolic::Expression>  R(R_AB_expr);
+    int one() { return 1; }
+    drake::math::RigidTransform<drake::symbolic::Expression>
+    asRigidTransformExpression() const {
+      Eigen::Matrix<drake::symbolic::Expression, 3, 3> R_AB_expr;
+      R_AB_expr << R_AB.coeff(0, 0).ToExpression(),
+          R_AB.coeff(0, 1).ToExpression(), R_AB.coeff(0, 2).ToExpression(),
+          R_AB.coeff(1, 0).ToExpression(), R_AB.coeff(1, 1).ToExpression(),
+          R_AB.coeff(1, 2).ToExpression(), R_AB.coeff(2, 0).ToExpression(),
+          R_AB.coeff(2, 1).ToExpression(), R_AB.coeff(2, 2).ToExpression();
+      math::RotationMatrix<drake::symbolic::Expression> R(R_AB_expr);
 
-        Vector3<drake::symbolic::Expression> p {
-        p_AB.coeff(0).ToExpression(), p_AB.coeff(1).ToExpression(), p_AB.coeff(2).ToExpression()
-        };
-        return drake::math::RigidTransform(R, p);
-    };
+      Vector3<drake::symbolic::Expression> p{p_AB.coeff(0).ToExpression(),
+                                             p_AB.coeff(1).ToExpression(),
+                                             p_AB.coeff(2).ToExpression()};
+      return drake::math::RigidTransform(R, p);
+    }
     // drake::math::RigidTransform<T> asRigidTransform() const{
     //     Eigen::Matrix<T,3,3>  R_AB_expr;
     //     R_AB_expr <<
@@ -73,7 +72,7 @@ class RationalForwardKinematics {
     //     Vector3<T> p {
     //     p_AB.coeff(0), p_AB.coeff(1), p_AB.coeff(2)
     //     };
-        // return drake::math::RigidTransform(R, p);
+    // return drake::math::RigidTransform(R, p);
   };
 
   struct LinkPoints {

--- a/multibody/rational_forward_kinematics/redundant_inequality_pruning.cc
+++ b/multibody/rational_forward_kinematics/redundant_inequality_pruning.cc
@@ -1,4 +1,8 @@
 #include "drake/multibody/rational_forward_kinematics/redundant_inequality_pruning.h"
+
+#include <limits>
+#include <list>
+
 #include "drake/solvers/solve.h"
 
 namespace drake {
@@ -8,54 +12,53 @@ const double kInf = std::numeric_limits<double>::infinity();
 std::vector<int> FindRedundantInequalitiesInHPolyhedronByIndex(
     const Eigen::Ref<const Eigen::MatrixXd>& C,
     const Eigen::Ref<const Eigen::VectorXd>& d) {
+  const int num_inequalities = C.rows();
+  const int num_vars = C.cols();
 
-    const int num_inequalities = C.rows();
-    const int num_vars = C.cols();
+  std::list<int> kept_indices;
+  for (int i = 0; i < num_inequalities; i++) {
+    kept_indices.push_back(i);
+  }
 
-    std::list<int> kept_indices;
-    for(int i = 0; i < num_inequalities; i++) {
-      kept_indices.push_back(i);
+  std::list<int> excluded_indices(0);
+
+  for (int excluded_index = 0; excluded_index < num_inequalities;
+       excluded_index++) {
+    solvers::MathematicalProgram prog;
+    solvers::VectorXDecisionVariable x =
+        prog.NewContinuousVariables(num_vars, "x");
+    std::list<int> cur_kept_indices = kept_indices;
+    cur_kept_indices.remove(excluded_index);
+
+    // constraint c^Tx <= d+1
+    prog.AddLinearConstraint(
+        C.row(excluded_index), Eigen::VectorXd::Constant(1, -kInf),
+        d.row(excluded_index) + Eigen::VectorXd::Ones(1), x);
+
+    // constraint Ax <= b
+    for (const int i : cur_kept_indices) {
+      prog.AddLinearConstraint(C.row(i), Eigen::VectorXd::Constant(1, -kInf),
+                               d.row(i), x);
     }
 
-    std::list<int> excluded_indices(0);
+    prog.AddLinearCost(-C.row(excluded_index), 0, x);
 
-    for (int excluded_index = 0; excluded_index < num_inequalities; excluded_index++){
-      solvers::MathematicalProgram prog;
-      solvers::VectorXDecisionVariable x = prog.NewContinuousVariables(num_vars, "x");
-      std::list<int>cur_kept_indices = kept_indices;
-      cur_kept_indices.remove(excluded_index);
+    auto result = solvers::Solve(prog);
 
-      // constraint c^Tx <= d+1
-      prog.AddLinearConstraint(C.row(excluded_index),Eigen::VectorXd::Constant(1, -kInf),
-                                 d.row(excluded_index)+Eigen::VectorXd::Ones(1), x);
-
-      // constraint Ax <= b
-      for (const int i : cur_kept_indices) {
-        prog.AddLinearConstraint(C.row(i),Eigen::VectorXd::Constant(1, -kInf),
-                                 d.row(i), x);
-      }
-
-      prog.AddLinearCost(-C.row(excluded_index), 0, x);
-
-      auto result = solvers::Solve(prog);
-
-      if (!result.is_success()){
-        // polyhedron is empty so exit as redundancy is ill-defined here
-        return std::vector<int> {};
-      }
-
-
-      // should I add an argument to make this stricter/more relaxed?
-      if (-result.get_optimal_cost() <= d(excluded_index)) {
-        excluded_indices.push_back(excluded_index);
-        kept_indices.remove(excluded_index);
-      }
+    if (!result.is_success()) {
+      // polyhedron is empty so exit as redundancy is ill-defined here
+      return std::vector<int>{};
     }
-    std::vector<int> ret(excluded_indices.begin(), excluded_indices.end());
-    return ret;
 
+    // should I add an argument to make this stricter/more relaxed?
+    if (-result.get_optimal_cost() <= d(excluded_index)) {
+      excluded_indices.push_back(excluded_index);
+      kept_indices.remove(excluded_index);
+    }
+  }
+  std::vector<int> ret(excluded_indices.begin(), excluded_indices.end());
+  return ret;
 }
 
-
-} // namespace multibody
-} // namespace drake
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/rational_forward_kinematics/test/rational_forward_kinematics_internal_test.cc
+++ b/multibody/rational_forward_kinematics/test/rational_forward_kinematics_internal_test.cc
@@ -48,7 +48,7 @@ void CheckChildInReshuffledBody(const MultibodyTree<double>& tree,
             GetInboardMobilizer(tree, inboard_mobilizer_body));
 }
 
-TEST_F(IiwaTest, TestAddChildrenToReshuffledBodyWithWorldAsRoot) {
+TEST_F(FinalizedIiwaTest, TestAddChildrenToReshuffledBodyWithWorldAsRoot) {
   ReshuffledBody reshuffled_world(world_, nullptr, nullptr);
   std::unordered_set<BodyIndex> visited;
   visited.emplace(world_);
@@ -85,7 +85,7 @@ TEST_F(IiwaTest, TestAddChildrenToReshuffledBodyWithWorldAsRoot) {
                 {world_, iiwa_link_[0], iiwa_link_[1], iiwa_link_[2]}));
 }
 
-TEST_F(IiwaTest, TestAddChildrenToReshuffledBodyWithLink3AsRoot) {
+TEST_F(FinalizedIiwaTest, TestAddChildrenToReshuffledBodyWithLink3AsRoot) {
   ReshuffledBody reshuffled_link_3(iiwa_link_[3], nullptr, nullptr);
   std::unordered_set<BodyIndex> visited;
   visited.insert(iiwa_link_[3]);
@@ -138,7 +138,7 @@ TEST_F(IiwaTest, TestAddChildrenToReshuffledBodyWithLink3AsRoot) {
                           iiwa_link_[3], iiwa_link_[4]}));
 }
 
-TEST_F(IiwaTest, TestReshuffleKinematicsTreeWithWorldAsRoot) {
+TEST_F(FinalizedIiwaTest, TestReshuffleKinematicsTreeWithWorldAsRoot) {
   ReshuffledBody reshuffled_world(world_, nullptr, nullptr);
   ReshuffleKinematicsTree(*iiwa_, &reshuffled_world);
 
@@ -164,7 +164,7 @@ TEST_F(IiwaTest, TestReshuffleKinematicsTreeWithWorldAsRoot) {
   EXPECT_EQ(reshuffled_link_i->children.size(), 0);
 }
 
-TEST_F(IiwaTest, TestReshuffleKinematicsTreeWithLink3AsRoot) {
+TEST_F(FinalizedIiwaTest, TestReshuffleKinematicsTreeWithLink3AsRoot) {
   ReshuffledBody reshuffled_link_3(iiwa_link_[3], nullptr, nullptr);
   ReshuffleKinematicsTree(*iiwa_, &reshuffled_link_3);
   EXPECT_EQ(reshuffled_link_3.body_index, iiwa_link_[3]);
@@ -195,7 +195,7 @@ TEST_F(IiwaTest, TestReshuffleKinematicsTreeWithLink3AsRoot) {
   EXPECT_EQ(reshuffled_link_i->children.size(), 0);
 }
 
-TEST_F(IiwaTest, FindShortestPath) {
+TEST_F(FinalizedIiwaTest, FindShortestPath) {
   auto path = FindShortestPath(*iiwa_, world_, iiwa_link_[7]);
   EXPECT_EQ(path, std::vector<BodyIndex>({world_, iiwa_link_[0], iiwa_link_[1],
                                           iiwa_link_[2], iiwa_link_[3],
@@ -219,7 +219,7 @@ TEST_F(IiwaTest, FindShortestPath) {
                                     iiwa_link_[0], world_}));
 }
 
-TEST_F(IiwaTest, FindBodyInTheMiddleOfChain) {
+TEST_F(FinalizedIiwaTest, FindBodyInTheMiddleOfChain) {
   EXPECT_EQ(FindBodyInTheMiddleOfChain(*iiwa_, iiwa_link_[0], iiwa_link_[1]),
             iiwa_link_[1]);
   EXPECT_EQ(FindBodyInTheMiddleOfChain(*iiwa_, iiwa_link_[1], iiwa_link_[0]),
@@ -240,7 +240,7 @@ TEST_F(IiwaTest, FindBodyInTheMiddleOfChain) {
             iiwa_link_[3]);
 }
 
-TEST_F(IiwaTest, FindMobilizersOnShortestPath) {
+TEST_F(FinalizedIiwaTest, FindMobilizersOnShortestPath) {
   EXPECT_EQ(FindMobilizersOnShortestPath(*iiwa_, iiwa_link_[0], iiwa_link_[1]),
             std::vector<MobilizerIndex>({iiwa_joint_[1]}));
 

--- a/multibody/rational_forward_kinematics/test/rational_forward_kinematics_test.cc
+++ b/multibody/rational_forward_kinematics/test/rational_forward_kinematics_test.cc
@@ -240,7 +240,7 @@ void CheckLinkKinematics(
   }
 }
 
-TEST_F(IiwaTest, CalcLinkPoses) {
+TEST_F(FinalizedIiwaTest, CalcLinkPoses) {
   RationalForwardKinematics rational_forward_kinematics(*iiwa_);
   EXPECT_EQ(rational_forward_kinematics.t().rows(), 7);
 
@@ -363,7 +363,7 @@ void CheckFindTOnPath(
   }
 }
 
-TEST_F(IiwaTest, FindTOnPath) {
+TEST_F(FinalizedIiwaTest, FindTOnPath) {
   RationalForwardKinematics rational_forward_kinematics(*iiwa_);
 
   CheckFindTOnPath(rational_forward_kinematics, world_, iiwa_link_[0], {});

--- a/multibody/rational_forward_kinematics/test/rational_forward_kinematics_test_utilities.cc
+++ b/multibody/rational_forward_kinematics/test/rational_forward_kinematics_test_utilities.cc
@@ -122,7 +122,7 @@ void IiwaTest::AddBox(
       CoulombFriction<double>());
   geometries->emplace_back(std::make_shared<const ConvexPolytope>(
       body_index, geometry_id, GenerateBoxVertices(box_size, X_BG)));
-};
+}
 
 void AddIiwaWithSchunk(const RigidTransformd& X_7S,
                        MultibodyPlant<double>* plant) {

--- a/multibody/rational_forward_kinematics/test/rational_forward_kinematics_test_utilities.cc
+++ b/multibody/rational_forward_kinematics/test/rational_forward_kinematics_test_utilities.cc
@@ -102,13 +102,10 @@ std::unique_ptr<MultibodyPlant<double>> ConstructDualArmIiwaPlant(
 
 IiwaTest::IiwaTest()
     : iiwa_(ConstructIiwaPlant("iiwa14_no_collision.sdf", false)),
-      iiwa_tree_(drake::multibody::internal::GetInternalTree(*iiwa_)),
       world_{iiwa_->world_body().index()} {
   for (int i = 0; i < 8; ++i) {
     iiwa_link_[i] =
         iiwa_->GetBodyByName("iiwa_link_" + std::to_string(i)).index();
-    iiwa_joint_[i] =
-        iiwa_tree_.get_topology().get_body(iiwa_link_[i]).inboard_mobilizer;
   }
 }
 
@@ -122,6 +119,18 @@ void IiwaTest::AddBox(
       CoulombFriction<double>());
   geometries->emplace_back(std::make_shared<const ConvexPolytope>(
       body_index, geometry_id, GenerateBoxVertices(box_size, X_BG)));
+}
+
+FinalizedIiwaTest::FinalizedIiwaTest()
+    : iiwa_(ConstructIiwaPlant("iiwa14_no_collision.sdf", true)),
+      iiwa_tree_(drake::multibody::internal::GetInternalTree(*iiwa_)),
+      world_{iiwa_->world_body().index()} {
+  for (int i = 0; i < 8; ++i) {
+    iiwa_link_[i] =
+        iiwa_->GetBodyByName("iiwa_link_" + std::to_string(i)).index();
+    iiwa_joint_[i] =
+        iiwa_tree_.get_topology().get_body(iiwa_link_[i]).inboard_mobilizer;
+  }
 }
 
 void AddIiwaWithSchunk(const RigidTransformd& X_7S,

--- a/multibody/rational_forward_kinematics/test/rational_forward_kinematics_test_utilities.h
+++ b/multibody/rational_forward_kinematics/test/rational_forward_kinematics_test_utilities.h
@@ -33,6 +33,9 @@ ConstructDualArmIiwaPlant(
     drake::multibody::ModelInstanceIndex* left_iiwa_instance,
     drake::multibody::ModelInstanceIndex* right_iiwa_instance);
 
+/** The iiwa plant here is not finalized, so that the user can add more
+ * collision geometries.
+ */
 class IiwaTest : public ::testing::Test {
  public:
   IiwaTest();
@@ -41,6 +44,19 @@ class IiwaTest : public ::testing::Test {
               const Eigen::Vector3d& box_size, BodyIndex body_index,
               const std::string& name,
               std::vector<std::shared_ptr<const ConvexPolytope>>* geometries);
+
+ protected:
+  std::unique_ptr<drake::multibody::MultibodyPlant<double>> iiwa_;
+  const drake::multibody::BodyIndex world_;
+  std::array<drake::multibody::BodyIndex, 8> iiwa_link_;
+};
+
+/**
+ * The iiwa plant is finalized at the test construction.
+ */
+class FinalizedIiwaTest : public ::testing::Test {
+ public:
+  FinalizedIiwaTest();
 
  protected:
   std::unique_ptr<drake::multibody::MultibodyPlant<double>> iiwa_;

--- a/multibody/rational_forward_kinematics/test/rational_forward_kinematics_test_utilities2.cc
+++ b/multibody/rational_forward_kinematics/test/rational_forward_kinematics_test_utilities2.cc
@@ -107,7 +107,7 @@ void IiwaTest::AddBox(
       CoulombFriction<double>());
   geometries->emplace_back(std::make_unique<const ConvexPolytope>(
       body_index, geometry_id, GenerateBoxVertices(box_size, X_BG)));
-};
+}
 
 void AddIiwaWithSchunk(const RigidTransformd& X_7S,
                        MultibodyPlant<double>* plant) {

--- a/multibody/rational_forward_kinematics/test/redundant_inequality_pruning_test.cc
+++ b/multibody/rational_forward_kinematics/test/redundant_inequality_pruning_test.cc
@@ -6,45 +6,46 @@ namespace drake {
 namespace multibody {
 namespace {
 
-GTEST_TEST(RedundantHyperplaneInequalities, PruneSimpleBoundingBox){
+GTEST_TEST(RedundantHyperplaneInequalities, PruneSimpleBoundingBox) {
   Eigen::Matrix<double, 12, 3> A_redundant;
   Eigen::Matrix<double, 12, 1> b_redundant;
 
   Eigen::MatrixXd I3 = Eigen::MatrixXd::Identity(3, 3);
   Eigen::MatrixXd one3 = Eigen::MatrixXd::Ones(3, 1);
-  const float scale= 0.25;
+  const float scale = 0.25;
 
   // clang-format off
   A_redundant << I3, -I3, I3, -I3;
   b_redundant << one3, one3, scale*one3, scale*one3;
   // clang-format on
 
-  std::vector<int> redundant_indices = FindRedundantInequalitiesInHPolyhedronByIndex(A_redundant, b_redundant);
-  std::vector<int> redundant_indices_expected = {0,1,2,3,4,5};
+  std::vector<int> redundant_indices =
+      FindRedundantInequalitiesInHPolyhedronByIndex(A_redundant, b_redundant);
+  std::vector<int> redundant_indices_expected = {0, 1, 2, 3, 4, 5};
 
   EXPECT_TRUE(redundant_indices == redundant_indices_expected);
-
 }
 
-GTEST_TEST(RedundantHyperplaneInequalities, PruneSimpleBoundingBox2){
+GTEST_TEST(RedundantHyperplaneInequalities, PruneSimpleBoundingBox2) {
   Eigen::Matrix<double, 5, 2> A_redundant;
-  Eigen::Matrix<double, 5, 1> b_redundant = Eigen::MatrixXd::Ones(5,1);
+  Eigen::Matrix<double, 5, 1> b_redundant = Eigen::MatrixXd::Ones(5, 1);
   b_redundant(4) = 0;
 
   // clang-format off
-  A_redundant <<  1, -1, // redundant
+  A_redundant <<  1, -1,  // redundant
                  -1,  1,
                  -1, -1,
-                  1,  1, // redundant
+                  1,  1,  // redundant
                   1,  0;
   // clang-format on
 
-  std::vector<int> redundant_indices = FindRedundantInequalitiesInHPolyhedronByIndex(A_redundant, b_redundant);
-  std::vector<int> redundant_indices_expected = {0,3};
+  std::vector<int> redundant_indices =
+      FindRedundantInequalitiesInHPolyhedronByIndex(A_redundant, b_redundant);
+  std::vector<int> redundant_indices_expected = {0, 3};
 
   EXPECT_TRUE(redundant_indices == redundant_indices_expected);
 }
 
-}
-} // namespace multibody
-} // namespace drake
+}  // namespace
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
There is still one test failure in rational_forward_kinematics_test.cc. That is intentional, as by applying my patch on symbolic_polynomial.cc, it won't get rid of the zero-coefficient term in the symbolic polynomial. This won't really cause problem in our SOS-IRIS region, as the SOS program is the same with additional zero-coefficient terms.