### PR TITLE
Add tightening to FindRedundantInequalities

### DIFF
--- a/multibody/rational_forward_kinematics/redundant_inequality_pruning.h
+++ b/multibody/rational_forward_kinematics/redundant_inequality_pruning.h
@@ -16,11 +16,14 @@ namespace multibody {
  * Given the C-space free region candidate C*t<=d,
  * find all the inequalities which are redundant by solving
  * a series of linear programs.
- * return the indices of the redundant inequalites
+ * @param tighten We remove the i'th row C.row(i) * t <= d(i) iff C.row(i) * t
+ * <= d(i) - tighten is redundant (namely the other rows of inequality
+ * constraints would imply C.row(i) * t <= d(i) - tighten).
+ * @return the indices of the redundant inequalites
  */
 std::vector<int> FindRedundantInequalitiesInHPolyhedronByIndex(
     const Eigen::Ref<const Eigen::MatrixXd>& C,
-    const Eigen::Ref<const Eigen::VectorXd>& d);
+    const Eigen::Ref<const Eigen::VectorXd>& d, double tol = 0.);
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/rational_forward_kinematics/test/redundant_inequality_pruning_test.cc
+++ b/multibody/rational_forward_kinematics/test/redundant_inequality_pruning_test.cc
@@ -46,6 +46,23 @@ GTEST_TEST(RedundantHyperplaneInequalities, PruneSimpleBoundingBox2) {
   EXPECT_TRUE(redundant_indices == redundant_indices_expected);
 }
 
+GTEST_TEST(RedundantHyperplaneInequalities, RemoveWithTighten) {
+  Eigen::Matrix<double, 5, 2> A;
+  // clang-format off
+  A << 1, 0,
+       0, 1,
+       -1, 0,
+       0, -1,
+       1, 0;
+  // clang-format on
+  Eigen::Matrix<double, 5, 1> b;
+  b << 1, 1, 1, 1, 0.5;
+  // With tighten=0, the first constraint x(0) <= 1 is redundant.
+  EXPECT_EQ(FindRedundantInequalitiesInHPolyhedronByIndex(A, b, 0.), std::vector<int>({0}));
+  // with tighten = 0.6, none of the constraint is redundant.
+  EXPECT_EQ(FindRedundantInequalitiesInHPolyhedronByIndex(A, b, 0.6).size(), 0);
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION
Also changed to use `std::unordered_map` with has O(1) complexity to remove objects, compared to O(n) complexity in list.