### PR TITLE
add an example of IIWA + shelf

### DIFF
--- a/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_welded_fingers.sdf
+++ b/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_welded_fingers.sdf
@@ -1,0 +1,262 @@
+<?xml version="1.0"?>
+<!-- This sdf file is based on schunk_wsg_50.sdf -->
+<sdf version="1.7">
+  <model name="Schunk_Gripper">
+    <link name="body">
+      <pose>0 -0.049133 0 0 0 0</pose>
+      <inertial>
+        <mass>0.988882</mass>
+        <inertia>
+          <ixx>0.162992</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.162992</iyy>
+          <iyz>0</iyz>
+          <izz>0.164814</izz>
+        </inertia>
+      </inertial>
+      <self_collide>0</self_collide>
+      <kinematic>0</kinematic>
+      <visual name="visual">
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>package://wsg_50_description/meshes/wsg_body.obj</uri>
+          </mesh>
+        </geometry>
+        <material>
+          <diffuse>0.7 0.7 0.7 1</diffuse>
+        </material>
+      </visual>
+      <collision name="body_collision">
+        <laser_retro>0</laser_retro>
+        <max_contacts>10</max_contacts>
+        <geometry>
+          <box>
+            <size>0.146 0.0725 0.05</size>
+          </box>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>1</mu>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+              <slip1>0</slip1>
+              <slip2>0</slip2>
+            </ode>
+            <torsional>
+              <coefficient>1</coefficient>
+              <patch_radius>0</patch_radius>
+              <surface_radius>0</surface_radius>
+              <use_patch_radius>1</use_patch_radius>
+              <ode>
+                <slip>0</slip>
+              </ode>
+            </torsional>
+          </friction>
+          <bounce>
+            <restitution_coefficient>0</restitution_coefficient>
+            <threshold>1e+06</threshold>
+          </bounce>
+          <contact>
+            <collide_without_contact>0</collide_without_contact>
+            <collide_without_contact_bitmask>1</collide_without_contact_bitmask>
+            <collide_bitmask>1</collide_bitmask>
+            <ode>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+              <max_vel>0.01</max_vel>
+              <min_depth>0</min_depth>
+            </ode>
+            <bullet>
+              <split_impulse>1</split_impulse>
+              <split_impulse_penetration_threshold>-0.01</split_impulse_penetration_threshold>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </bullet>
+          </contact>
+        </surface>
+      </collision>
+    </link>
+    <frame name="body_frame">
+      <pose relative_to="body"/>
+    </frame>
+    <link name="left_finger">
+      <pose>-0.06 0.028 0 0 3.141592 0</pose>
+      <inertial>
+        <mass>0.05</mass>
+        <inertia>
+          <ixx>0.16</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.16</iyy>
+          <iyz>0</iyz>
+          <izz>0.16</izz>
+        </inertia>
+      </inertial>
+      <self_collide>0</self_collide>
+      <kinematic>0</kinematic>
+      <visual name="visual">
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>package://wsg_50_description/meshes/finger_without_tip.obj</uri>
+          </mesh>
+        </geometry>
+        <material>
+          <diffuse>0.2 0.2 0.2 1</diffuse>
+        </material>
+      </visual>
+      <collision name="left_collision">
+        <laser_retro>0</laser_retro>
+        <max_contacts>10</max_contacts>
+        <geometry>
+          <box>
+            <size>0.012 0.082 0.02</size>
+          </box>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>1</mu>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+              <slip1>0</slip1>
+              <slip2>0</slip2>
+            </ode>
+            <torsional>
+              <coefficient>1</coefficient>
+              <patch_radius>0</patch_radius>
+              <surface_radius>0</surface_radius>
+              <use_patch_radius>1</use_patch_radius>
+              <ode>
+                <slip>0</slip>
+              </ode>
+            </torsional>
+          </friction>
+          <bounce>
+            <restitution_coefficient>0</restitution_coefficient>
+            <threshold>1e+06</threshold>
+          </bounce>
+          <contact>
+            <collide_without_contact>0</collide_without_contact>
+            <collide_without_contact_bitmask>1</collide_without_contact_bitmask>
+            <collide_bitmask>1</collide_bitmask>
+            <ode>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+              <max_vel>0.01</max_vel>
+              <min_depth>0</min_depth>
+            </ode>
+            <bullet>
+              <split_impulse>1</split_impulse>
+              <split_impulse_penetration_threshold>-0.01</split_impulse_penetration_threshold>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </bullet>
+          </contact>
+        </surface>
+      </collision>
+    </link>
+    <link name="right_finger">
+      <pose>0.06 0.028 0 0 0 0</pose>
+      <inertial>
+        <mass>0.05</mass>
+        <inertia>
+          <ixx>0.16</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.16</iyy>
+          <iyz>0</iyz>
+          <izz>0.16</izz>
+        </inertia>
+      </inertial>
+      <self_collide>0</self_collide>
+      <kinematic>0</kinematic>
+      <visual name="visual">
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>package://wsg_50_description/meshes/finger_without_tip.obj</uri>
+          </mesh>
+        </geometry>
+        <material>
+          <diffuse>0.2 0.2 0.2 1</diffuse>
+        </material>
+      </visual>
+      <collision name="right_collision">
+        <laser_retro>0</laser_retro>
+        <max_contacts>10</max_contacts>
+        <geometry>
+          <box>
+            <size>0.012 0.082 0.02</size>
+          </box>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>1</mu>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+              <slip1>0</slip1>
+              <slip2>0</slip2>
+            </ode>
+            <torsional>
+              <coefficient>1</coefficient>
+              <patch_radius>0</patch_radius>
+              <surface_radius>0</surface_radius>
+              <use_patch_radius>1</use_patch_radius>
+              <ode>
+                <slip>0</slip>
+              </ode>
+            </torsional>
+          </friction>
+          <bounce>
+            <restitution_coefficient>0</restitution_coefficient>
+            <threshold>1e+06</threshold>
+          </bounce>
+          <contact>
+            <collide_without_contact>0</collide_without_contact>
+            <collide_without_contact_bitmask>1</collide_without_contact_bitmask>
+            <collide_bitmask>1</collide_bitmask>
+            <ode>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+              <max_vel>0.01</max_vel>
+              <min_depth>0</min_depth>
+            </ode>
+            <bullet>
+              <split_impulse>1</split_impulse>
+              <split_impulse_penetration_threshold>-0.01</split_impulse_penetration_threshold>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </bullet>
+          </contact>
+        </surface>
+      </collision>
+    </link>
+    <joint name="left_finger_sliding_joint" type="fixed">
+      <parent>body</parent>
+      <child>left_finger</child>
+    </joint>
+    <joint name="right_finger_sliding_joint" type="fixed">
+      <parent>body</parent>
+      <child>right_finger</child>
+    </joint>
+    <static>0</static>
+    <allow_auto_disable>1</allow_auto_disable>
+  </model>
+</sdf>

--- a/multibody/rational_forward_kinematics/BUILD.bazel
+++ b/multibody/rational_forward_kinematics/BUILD.bazel
@@ -249,4 +249,23 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_binary(
+    name = "iiwa_shelf_demo",
+    srcs = ["test/iiwa_shelf_demo.cc"],
+    data = [
+        "//examples/kuka_iiwa_arm:models",
+        "//manipulation/models/iiwa_description:models",
+        "//manipulation/models/wsg_50_description:models",
+        "//sos_iris_certifier:models",
+    ],
+    deps = [
+        ":cspace_free_region",
+        "//common:find_resource",
+        "//geometry:meshcat_visualizer",
+        "//multibody/inverse_kinematics",
+        "//multibody/parsing:parser",
+        "//multibody/plant",
+    ],
+)
+
 add_lint_tests()

--- a/multibody/rational_forward_kinematics/cspace_free_region.h
+++ b/multibody/rational_forward_kinematics/cspace_free_region.h
@@ -186,6 +186,10 @@ class CspaceFreeRegion {
     std::vector<symbolic::Polynomial> verified_polynomials;
   };
 
+  /* @note I strongly recommend NOT to use this function. I created this
+   * function for fast prototyping. It is very slow when constructing the
+   * program (as it incurs a lot of dynamic memory allocation.
+   */
   CspacePolytopeProgramReturn ConstructProgramForCspacePolytope(
       const Eigen::Ref<const Eigen::VectorXd>& q_star,
       const std::vector<LinkVertexOnPlaneSideRational>& rationals,

--- a/multibody/rational_forward_kinematics/test/iiwa_shelf_demo.cc
+++ b/multibody/rational_forward_kinematics/test/iiwa_shelf_demo.cc
@@ -1,0 +1,198 @@
+#include <iostream>
+
+#include "drake/common/find_resource.h"
+#include "drake/geometry/collision_filter_declaration.h"
+#include "drake/geometry/meshcat_visualizer.h"
+#include "drake/geometry/optimization/hpolyhedron.h"
+#include "drake/multibody/inverse_kinematics/inverse_kinematics.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/rational_forward_kinematics/cspace_free_region.h"
+#include "drake/solvers/common_solver_option.h"
+#include "drake/solvers/solve.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+namespace drake {
+namespace multibody {
+class IiwaDiagram {
+ public:
+  IiwaDiagram() : meshcat_{std::make_shared<geometry::Meshcat>()} {
+    systems::DiagramBuilder<double> builder;
+    auto [plant, sg] = AddMultibodyPlantSceneGraph(&builder, 0.);
+    plant_ = &plant;
+    scene_graph_ = &sg;
+
+    multibody::Parser parser(plant_);
+    const std::string iiwa_file_path = FindResourceOrThrow(
+        "drake/manipulation/models/iiwa_description/sdf/"
+        "iiwa14_no_collision.sdf");
+    const auto iiwa_instance = parser.AddModelFromFile(iiwa_file_path, "iiwa");
+    plant_->WeldFrames(plant_->world_frame(),
+                       plant_->GetFrameByName("iiwa_link_0"));
+
+    const std::string schunk_file_path = FindResourceOrThrow(
+        "drake/manipulation/models/wsg_50_description/sdf/"
+        "schunk_wsg_50_welded_fingers.sdf");
+
+    const Frame<double>& link7 =
+        plant_->GetFrameByName("iiwa_link_7", iiwa_instance);
+    const math::RigidTransformd X_7G(
+        math::RollPitchYaw<double>(M_PI_2, 0, M_PI_2),
+        Eigen::Vector3d(0, 0, 0.114));
+    const auto wsg_instance =
+        parser.AddModelFromFile(schunk_file_path, "gripper");
+    const auto& schunk_frame = plant_->GetFrameByName("body", wsg_instance);
+    plant_->WeldFrames(link7, schunk_frame, X_7G);
+    // SceneGraph should ignore the collision between any geometries on the
+    // gripper.
+    geometry::GeometrySet gripper_geometries;
+    auto add_gripper_geometries = [this, wsg_instance, &gripper_geometries](
+                                      const std::string& body_name) {
+      const geometry::FrameId frame_id = plant_->GetBodyFrameIdOrThrow(
+          plant_->GetBodyByName(body_name, wsg_instance).index());
+      gripper_geometries.Add(frame_id);
+    };
+    add_gripper_geometries("body");
+    add_gripper_geometries("left_finger");
+    add_gripper_geometries("right_finger");
+    scene_graph_->collision_filter_manager().Apply(
+        geometry::CollisionFilterDeclaration().ExcludeWithin(
+            gripper_geometries));
+
+    const std::string shelf_file_path =
+        FindResourceOrThrow("drake/sos_iris_certifier/shelves.sdf");
+    const auto shelf_instance =
+        parser.AddModelFromFile(shelf_file_path, "shelves");
+    const auto& shelf_frame =
+        plant_->GetFrameByName("shelves_body", shelf_instance);
+    const math::RigidTransformd X_WShelf(Eigen::Vector3d(0.8, 0, 0.4));
+    plant_->WeldFrames(plant_->world_frame(), shelf_frame, X_WShelf);
+
+    plant_->Finalize();
+
+    visualizer_ = &geometry::MeshcatVisualizer<double>::AddToBuilder(
+        &builder, *scene_graph_, meshcat_);
+    diagram_ = builder.Build();
+  }
+
+  const systems::Diagram<double>& diagram() const { return *diagram_; }
+
+  const multibody::MultibodyPlant<double>& plant() const { return *plant_; }
+
+  const geometry::SceneGraph<double>& scene_graph() const {
+    return *scene_graph_;
+  }
+
+ private:
+  std::unique_ptr<systems::Diagram<double>> diagram_;
+  multibody::MultibodyPlant<double>* plant_;
+  geometry::SceneGraph<double>* scene_graph_;
+  std::shared_ptr<geometry::Meshcat> meshcat_;
+  geometry::MeshcatVisualizer<double>* visualizer_;
+};
+
+Eigen::VectorXd FindInitialPosture(const MultibodyPlant<double>& plant,
+                                   systems::Context<double>* plant_context) {
+  InverseKinematics ik(plant, plant_context);
+  const auto& link7 = plant.GetFrameByName("iiwa_link_7");
+  const auto& shelf = plant.GetFrameByName("shelves_body");
+  ik.AddPositionConstraint(link7, Eigen::Vector3d::Zero(), shelf,
+                           Eigen::Vector3d(-0.4, -0.2, -0.2),
+                           Eigen::Vector3d(-.1, 0.2, 0.2));
+  ik.AddMinimumDistanceConstraint(0.02);
+
+  Eigen::Matrix<double, 7, 1> q_init;
+  q_init << 0.1, 0.3, 0.2, 0.5, 0.4, 0.3, 0.2;
+  ik.get_mutable_prog()->SetInitialGuess(ik.q(), q_init);
+  const auto result = solvers::Solve(ik.prog());
+  if (!result.is_success()) {
+    drake::log()->warn("Cannot find the posture\n");
+  }
+  return result.GetSolution(ik.q());
+}
+
+void BuildCandidateCspacePolytope(const Eigen::VectorXd q_free,
+                                  Eigen::MatrixXd* C, Eigen::VectorXd* d) {
+  const int C_rows = 23;
+  C->resize(C_rows, 7);
+  // Create arbitrary polytope normals.
+  // clang-format off
+  (*C) << 0.5, 0.3, 0.2, -0.1, -1, 0, 0.5,
+          -0.1, 0.4, 0.2, 0.1, 0.5, -0.2, 0.3,
+          0.4, 1.2, -0.3, 0.2, 0.1, 0.4, 0.5,
+          -0.5, -2, -1.5, 0.3, 0.6, 0.1, -0.2,
+          0.2, 0.1, -0.5, 0.3, 0.4, 1.4, 0.5,
+          0.1, -0.5, 0.4, 1.5, -0.3, 0.2, 0.1,
+          0.2, 0.3, 1.3, 0.2, -0.3, -0.5, -0.2,
+          1.4, 0.1, -0.1, 0.2, -0.3, 0.1, 0.5,
+          -1.1, 0.2, 0.3, -0.1, 0.5, 0.2, -0.1,
+          0.2, -0.3, -1.2, 0.5, -0.3, 0.1, 0.3,
+          0.2, -1.5, 0.1, 0.4, -0.3, -0.2, 0.6,
+          0.1, 0.4, -0.2, 0.3, 0.9, -0.5, 0.8,
+          -0.2, 0.3, -0.1, 0.8, -0.4, 0.2, 1.4,
+          0.1, -0.2, 0.2, -0.3, 1.2, -0.3, 0.1,
+          0.3, -0.1, 0.2, 0.5, -0.3, -2.1, 1.2,
+          0.4, -0.3, 1.5, -0.3, 1.8, -0.1, 0.4,
+          1.2, -0.3, 0.4, 0.8, 1.2, -0.4, -0.8,
+          0.4, -0.2, 0.5, 1.4, 0.7, -0.2, -0.9,
+          -0.1, 0.4, -0.2, 0.3, 1.5, 0.1, -0.6,
+          -0.1, -0.3, 0.2, 1.1, -1.2, 1.3, 2.1,
+          0.1, -0.4, 0.2, 1.3, 1.2, 0.3, -1.1,
+          0.1, -1.4, 0.2, 0.3, 0.2, 0.3, -0.7,
+          -0.3, -0.5, 0.4, -1.5, -0.2, 1.3, -2.1;
+  // clang-format on
+  for (int i = 0; i < C_rows; ++i) {
+    C->row(i).normalize();
+  }
+  *d = (*C) * (q_free / 2).array().tan().matrix() +
+       0.0001 * Eigen::VectorXd::Ones(C_rows);
+  if (!geometry::optimization::HPolyhedron(*C, *d).IsBounded()) {
+    throw std::runtime_error("C*t <= d is not bounded");
+  }
+}
+
+int DoMain() {
+  const IiwaDiagram iiwa_diagram{};
+  auto diagram_context = iiwa_diagram.diagram().CreateDefaultContext();
+  auto& plant_context =
+      iiwa_diagram.plant().GetMyMutableContextFromRoot(diagram_context.get());
+  const auto q0 = FindInitialPosture(iiwa_diagram.plant(), &plant_context);
+  iiwa_diagram.plant().SetPositions(&plant_context, q0);
+  iiwa_diagram.diagram().Publish(*diagram_context);
+
+  Eigen::MatrixXd C_init;
+  Eigen::VectorXd d_init;
+  BuildCandidateCspacePolytope(q0, &C_init, &d_init);
+
+  const CspaceFreeRegion dut(iiwa_diagram.diagram(), &(iiwa_diagram.plant()),
+                             &(iiwa_diagram.scene_graph()),
+                             SeparatingPlaneOrder::kAffine,
+                             CspaceRegionType::kGenericPolytope);
+
+  CspaceFreeRegion::FilteredCollisionPairs filtered_collision_pairs{};
+
+  CspaceFreeRegion::BinarySearchOption binary_search_option{
+      .epsilon_max = 0.01, .epsilon_min = 0., .epsilon_tol = 0.005};
+  solvers::SolverOptions solver_options;
+  solver_options.SetOption(solvers::CommonSolverOption::kPrintToConsole, false);
+  Eigen::VectorXd d_binary_search;
+  Eigen::VectorXd q_star = Eigen::Matrix<double, 7, 1>::Zero();
+  dut.CspacePolytopeBinarySearch(q_star, filtered_collision_pairs, C_init,
+                                 d_init, binary_search_option, solver_options,
+                                 &d_binary_search);
+  CspaceFreeRegion::BilinearAlternationOption bilinear_alternation_option{
+      .max_iters = 10, .convergence_tol = 0.001};
+  Eigen::MatrixXd C_final;
+  Eigen::VectorXd d_final;
+  Eigen::MatrixXd P_final;
+  Eigen::VectorXd q_final;
+  dut.CspacePolytopeBilinearAlternation(
+      q_star, filtered_collision_pairs, C_init, d_binary_search,
+      bilinear_alternation_option, solver_options, &C_final, &d_final, &P_final,
+      &q_final);
+
+  return 0;
+}
+}  // namespace multibody
+}  // namespace drake
+
+int main() { return drake::multibody::DoMain(); }


### PR DESCRIPTION
The bilinear alternation should increase the inscribed ellipsoid volume.
But sometimes it decreases.

I suspect this is a numerical problem of Mosek, the evidence is that if I fix the inscribed ellipsoid to the value found in the previous iteration, then the "lagrangian program" is still feasible, but if I allow the inscribed ellipsoid to change, it finds an ellipsoid with smaller volume, although the objective is to maximize the ellipsoid volume.

I am going to try to change the objective from log(det(P)) to power(det(P), 1/m). The former objective uses an exponential cone, while the latter objective replaces the exponential cone with second order cones. Hence I expect the latter to have better numerical performance. I will send a separate PR to do this.

BTW, here is the test scenario, I use a 7 DOF iiwa with boxed schunk gripper and the shelf. This is the seed posture
![iiwa_shelf](https://user-images.githubusercontent.com/6314000/149269232-dd726011-c563-43c0-929a-53e16fcc57c3.png)

One thing to note is that the optimization takes a lot longer than I expected. Now the Lagrangian step takes ~2 minutes, and the polytope step takes 3s. I am checking why it takes so long.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alexandreamice/drake/11)
<!-- Reviewable:end -->
