### PR TITLE
Support sphere and capsule collision geometries

### DIFF
--- a/bindings/pydrake/multibody/rational_forward_kinematics_py.cc
+++ b/bindings/pydrake/multibody/rational_forward_kinematics_py.cc
@@ -8,6 +8,7 @@
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/multibody/rational_forward_kinematics/collision_geometry.h"
 #include "drake/multibody/rational_forward_kinematics/cspace_free_region.h"
 #include "drake/multibody/rational_forward_kinematics/generate_monomial_basis_util.h"
 #include "drake/multibody/rational_forward_kinematics/rational_forward_kinematics.h"
@@ -107,16 +108,22 @@ PYBIND11_MODULE(rational_forward_kinematics, m) {
 
   // Pose
   constexpr auto& doc = pydrake_doc.drake.multibody;
-  py::class_<multibody::ConvexPolytope>(
-      m, "ConvexPolytope", doc.ConvexPolytope.doc)
-      .def(py::init<BodyIndex, geometry::GeometryId,
-               const Eigen::Ref<const Eigen::Matrix3Xd>>(),
-          py::arg("body_index"), py::arg("id"), py::arg("vertices"),
-          doc.ConvexPolytope.doc)
-      .def("p_BV", &ConvexPolytope::p_BV, doc.ConvexPolytope.p_BV.doc)
-      .def("get_id", &ConvexPolytope::get_id, doc.ConvexGeometry.get_id.doc)
-      .def("body_index", &ConvexPolytope::body_index,
-          doc.ConvexGeometry.body_index.doc);
+
+  py::enum_<multibody::CollisionGeometryType>(
+      m, "CollisionGeometryType", doc.CollisionGeometryType.doc)
+      .value("kPolytope", multibody::CollisionGeometryType::kPolytope,
+          doc.CollisionGeometryType.kPolytope.doc)
+      .value("kSphere", multibody::CollisionGeometryType::kSphere,
+          doc.CollisionGeometryType.kSphere.doc);
+
+  py::class_<multibody::CollisionGeometry>(
+      m, "CollisionGeometry", doc.CollisionGeometry.doc)
+      .def("type", &CollisionGeometry::type, doc.CollisionGeometryType.doc)
+      .def("geometry", &CollisionGeometry::geometry, py_rvp::reference_internal,
+          doc.CollisionGeometry.geometry.doc)
+      .def("body_index", &CollisionGeometry::body_index,
+          doc.CollisionGeometry.body_index.doc)
+      .def("id", &CollisionGeometry::id, doc.CollisionGeometry.id.doc);
 
   py::enum_<multibody::SeparatingPlaneOrder>(
       m, "SeparatingPlaneOrder", doc.SeparatingPlaneOrder.doc)
@@ -128,19 +135,21 @@ PYBIND11_MODULE(rational_forward_kinematics, m) {
   // SeparatingPlane
   py::class_<multibody::SeparatingPlane>(
       m, "SeparatingPlane", doc.SeparatingPlane.doc)
-      .def_readonly("a", &SeparatingPlane::a, py_rvp::copy, doc.SeparatingPlane.a.doc)
+      .def_readonly(
+          "a", &SeparatingPlane::a, py_rvp::copy, doc.SeparatingPlane.a.doc)
       .def_readonly("b", &SeparatingPlane::b, doc.SeparatingPlane.b.doc)
-      .def_readonly("positive_side_polytope",
-          &SeparatingPlane::positive_side_polytope,
-          doc.SeparatingPlane.positive_side_polytope.doc)
-      .def_readonly("negative_side_polytope",
-          &SeparatingPlane::negative_side_polytope,
-          doc.SeparatingPlane.negative_side_polytope.doc)
+      .def_readonly("positive_side_geometry",
+          &SeparatingPlane::positive_side_geometry,
+          doc.SeparatingPlane.positive_side_geometry.doc)
+      .def_readonly("negative_side_geometry",
+          &SeparatingPlane::negative_side_geometry,
+          doc.SeparatingPlane.negative_side_geometry.doc)
       .def_readonly("expressed_link", &SeparatingPlane::expressed_link,
           doc.SeparatingPlane.expressed_link.doc)
       .def_readonly(
           "order", &SeparatingPlane::order, doc.SeparatingPlane.order.doc)
-      .def_readonly("decision_variables", &SeparatingPlane::decision_variables, py_rvp::copy, doc.SeparatingPlane.a.doc);
+      .def_readonly("decision_variables", &SeparatingPlane::decision_variables,
+          py_rvp::copy, doc.SeparatingPlane.a.doc);
 
   // PlaneSide
   py::enum_<PlaneSide>(m, "PlaneSide", doc.PlaneSide.doc)
@@ -156,28 +165,30 @@ PYBIND11_MODULE(rational_forward_kinematics, m) {
       .def_readonly("lagrangian_type", &VerificationOption::lagrangian_type,
           doc.VerificationOption.lagrangian_type.doc);
 
-  // LinkVertexOnPlaneSideRational
-  py::class_<LinkVertexOnPlaneSideRational>(
-      m, "LinkVertexOnPlaneSideRational", doc.LinkVertexOnPlaneSideRational.doc)
-      .def_readonly("rational", &LinkVertexOnPlaneSideRational::rational,
-          doc.LinkVertexOnPlaneSideRational.rational.doc)
-      .def_readonly("link_polytope",
-          &LinkVertexOnPlaneSideRational::link_polytope,
-          doc.LinkVertexOnPlaneSideRational.link_polytope.doc)
+  // LinkOnPlaneSideRational
+  py::class_<LinkOnPlaneSideRational>(
+      m, "LinkOnPlaneSideRational", doc.LinkOnPlaneSideRational.doc)
+      .def_readonly("rational", &LinkOnPlaneSideRational::rational,
+          doc.LinkOnPlaneSideRational.rational.doc)
+      .def_readonly("link_geometry", &LinkOnPlaneSideRational::link_geometry,
+          doc.LinkOnPlaneSideRational.link_geometry.doc)
       .def_readonly("expressed_body_index",
-          &LinkVertexOnPlaneSideRational::expressed_body_index,
-          doc.LinkVertexOnPlaneSideRational.expressed_body_index.doc)
-      .def_readonly("other_side_link_polytope",
-          &LinkVertexOnPlaneSideRational::other_side_link_polytope,
-          doc.LinkVertexOnPlaneSideRational.other_side_link_polytope.doc)
-      .def_readonly("a_A", &LinkVertexOnPlaneSideRational::a_A,
-          doc.LinkVertexOnPlaneSideRational.a_A.doc)
-      .def_readonly("b", &LinkVertexOnPlaneSideRational::b,
-          doc.LinkVertexOnPlaneSideRational.b.doc)
-      .def_readonly("plane_side", &LinkVertexOnPlaneSideRational::plane_side,
-          doc.LinkVertexOnPlaneSideRational.plane_side.doc)
-      .def_readonly("plane_order", &LinkVertexOnPlaneSideRational::plane_order,
-          doc.LinkVertexOnPlaneSideRational.plane_order.doc);
+          &LinkOnPlaneSideRational::expressed_body_index,
+          doc.LinkOnPlaneSideRational.expressed_body_index.doc)
+      .def_readonly("other_side_link_geometry",
+          &LinkOnPlaneSideRational::other_side_link_geometry,
+          doc.LinkOnPlaneSideRational.other_side_link_geometry.doc)
+      .def_readonly("a_A", &LinkOnPlaneSideRational::a_A,
+          doc.LinkOnPlaneSideRational.a_A.doc)
+      .def_readonly(
+          "b", &LinkOnPlaneSideRational::b, doc.LinkOnPlaneSideRational.b.doc)
+      .def_readonly("plane_side", &LinkOnPlaneSideRational::plane_side,
+          doc.LinkOnPlaneSideRational.plane_side.doc)
+      .def_readonly("plane_order", &LinkOnPlaneSideRational::plane_order,
+          doc.LinkOnPlaneSideRational.plane_order.doc)
+      .def_readonly("lorentz_cone_constraints",
+          &LinkOnPlaneSideRational::lorentz_cone_constraints,
+          doc.LinkOnPlaneSideRational.lorentz_cone_constraints.doc);
 
   // CspaceRegionType
   py::enum_<CspaceRegionType>(m, "CspaceRegionType", doc.CspaceRegionType.doc)
@@ -272,13 +283,15 @@ PYBIND11_MODULE(rational_forward_kinematics, m) {
   cspace_cls.def(
       py::init<const systems::Diagram<double>&, const MultibodyPlant<double>*,
           const geometry::SceneGraph<double>*, SeparatingPlaneOrder,
-          CspaceRegionType>(),
-      doc.CspaceFreeRegion.ctor.doc);
+          CspaceRegionType, double>(),
+      py::arg("diagram"), py::arg("plant"), py::arg("scene_graph"),
+      py::arg("plane_order"), py::arg("cspace_region_type"),
+      py::arg("separating_polytope_delta") = 1., doc.CspaceFreeRegion.ctor.doc);
 
   cspace_cls
-      .def("map_polytopes_to_separating_planes",
-          &CspaceFreeRegion::map_polytopes_to_separating_planes,
-          doc.CspaceFreeRegion.map_polytopes_to_separating_planes.doc)
+      .def("map_collisions_to_separating_planes",
+          &CspaceFreeRegion::map_collisions_to_separating_planes,
+          doc.CspaceFreeRegion.map_collisions_to_separating_planes.doc)
       .def("GenerateLinkOnOneSideOfPlaneRationals",
           &CspaceFreeRegion::GenerateLinkOnOneSideOfPlaneRationals,
           py::arg("q_star"), py::arg("filtered_collision_pairs"),
@@ -335,16 +348,21 @@ PYBIND11_MODULE(rational_forward_kinematics, m) {
             VectorX<symbolic::Variable> verified_gram_vars;
             VectorX<symbolic::Variable> separating_plane_vars;
             std::vector<std::vector<int>> separating_plane_to_tuples;
+            std::vector<
+                std::vector<solvers::Binding<solvers::LorentzConeConstraint>>>
+                separating_plane_to_lorentz_cone_constraints;
             self->GenerateTuplesForBilinearAlternation(q_star,
                 filtered_collision_pairs, C_rows, &alternation_tuples,
                 &d_minus_Ct, &t_lower, &t_upper, &t_minus_t_lower,
                 &t_upper_minus_t, &C, &d, &lagrangian_gram_vars,
                 &verified_gram_vars, &separating_plane_vars,
-                &separating_plane_to_tuples);
+                &separating_plane_to_tuples,
+                &separating_plane_to_lorentz_cone_constraints);
             return std::make_tuple(alternation_tuples, d_minus_Ct, t_lower,
                 t_upper, t_minus_t_lower, t_upper_minus_t, C, d,
                 lagrangian_gram_vars, verified_gram_vars, separating_plane_vars,
-                separating_plane_to_tuples);
+                separating_plane_to_tuples,
+                separating_plane_to_lorentz_cone_constraints);
           },
           py::arg("q_star"), py::arg("filtered_collision_pairs"),
           py::arg("C_rows"),
@@ -359,26 +377,33 @@ PYBIND11_MODULE(rational_forward_kinematics, m) {
               const VectorX<symbolic::Variable>& lagrangian_gram_vars,
               const VectorX<symbolic::Variable>& verified_gram_vars,
               const VectorX<symbolic::Variable>& separating_plane_vars,
+              const std::vector<
+                  solvers::Binding<solvers::LorentzConeConstraint>>&
+                  separating_plane_lorentz_cone_constraints,
               const Eigen::Ref<const Eigen::VectorXd>& t_lower,
               const Eigen::Ref<const Eigen::VectorXd>& t_upper,
               const VerificationOption& option,
               std::optional<double> redundant_tighten) {
             auto prog = self->ConstructLagrangianProgram(alternation_tuples, C,
                 d, lagrangian_gram_vars, verified_gram_vars,
-                separating_plane_vars, t_lower, t_upper, option,
-                redundant_tighten, nullptr, nullptr);
+                separating_plane_vars,
+                separating_plane_lorentz_cone_constraints, t_lower, t_upper,
+                option, redundant_tighten, nullptr, nullptr);
             return prog;
           },
           py::arg("alternation_tuples"), py::arg("C"), py::arg("d"),
           py::arg("lagrangian_gram_vars"), py::arg("verified_gram_vars"),
-          py::arg("separating_plane_vars"), py::arg("t_lower"),
-          py::arg("t_upper"), py::arg("option"), py::arg("redundant_tighten"),
+          py::arg("separating_plane_vars"),
+          py::arg("separating_plane_lorentz_cone_constraints"),
+          py::arg("t_lower"), py::arg("t_upper"), py::arg("option"),
+          py::arg("redundant_tighten"),
           doc.CspaceFreeRegion.ConstructLagrangianProgram.doc)
       .def("ConstructPolytopeProgram",
           &CspaceFreeRegion::ConstructPolytopeProgram,
           py::arg("alternation_tuples"), py::arg("C"), py::arg("d"),
           py::arg("d_minus_Ct"), py::arg("lagrangian_gram_var_vals"),
           py::arg("verified_gram_vars"), py::arg("separating_plane_vars"),
+          py::arg("separating_plane_lorentz_cone_constraints"),
           py::arg("t_minus_t_lower"), py::arg("t_upper_minus_t"),
           py::arg("option"), doc.CspaceFreeRegion.ConstructPolytopeProgram.doc)
       .def(
@@ -437,8 +462,8 @@ PYBIND11_MODULE(rational_forward_kinematics, m) {
       .def("separating_planes", &CspaceFreeRegion::separating_planes,
           py_rvp::reference, doc.CspaceFreeRegion.separating_planes.doc);
 
-  m.def("GetConvexPolytopes", &GetConvexPolytopes, py::arg("diagram"),
-      py::arg("plant"), py::arg("scene_graph"), doc.GetConvexPolytopes.doc);
+  m.def("GetCollisionGeometries", &GetCollisionGeometries, py::arg("diagram"),
+      py::arg("plant"), py::arg("scene_graph"), doc.GetCollisionGeometries.doc);
 
   m.def("AddInscribedEllipsoid", &AddInscribedEllipsoid, py::arg("prog"),
        py::arg("C"), py::arg("d"), py::arg("t_lower"), py::arg("t_upper"),

--- a/bindings/pydrake/multibody/test/rational_forward_kinematics_test.py
+++ b/bindings/pydrake/multibody/test/rational_forward_kinematics_test.py
@@ -41,31 +41,39 @@ class IiwaCspaceTest(unittest.TestCase):
         self.plant.Finalize()
         self.diagram = builder.Build()
 
-    def test_get_convex_polytopes(self):
-        polytope_geometries = mut.GetConvexPolytopes(
+    def test_get_collision_geometries(self):
+        collision_geometries = mut.GetCollisionGeometries(
             diagram=self.diagram,
             plant=self.plant,
             scene_graph=self.scene_graph)
-        self.assertEqual(len(polytope_geometries), 3)
+        self.assertEqual(len(collision_geometries), 3)
 
     def test_cspace_free_region_constructor(self):
-        dut = mut.CspaceFreeRegion(self.diagram, self.plant, self.scene_graph,
+        dut = mut.CspaceFreeRegion(self.diagram,
+                                   self.plant,
+                                   self.scene_graph,
                                    mut.SeparatingPlaneOrder.kAffine,
-                                   mut.CspaceRegionType.kGenericPolytope)
+                                   mut.CspaceRegionType.kGenericPolytope,
+                                   separating_polytope_delta=1.)
         self.assertEqual(len(dut.separating_planes()), 3)
 
     def test_generate_tuples_for_bilinear_alternation(self):
-        dut = mut.CspaceFreeRegion(self.diagram, self.plant, self.scene_graph,
+        dut = mut.CspaceFreeRegion(self.diagram,
+                                   self.plant,
+                                   self.scene_graph,
                                    mut.SeparatingPlaneOrder.kAffine,
-                                   mut.CspaceRegionType.kGenericPolytope)
+                                   mut.CspaceRegionType.kGenericPolytope,
+                                   separating_polytope_delta=1.)
         q_star = np.zeros(7)
         alternation_tuples, d_minus_Ct, t_lower, t_upper, t_minus_t_lower,\
             t_upper_minus_t, C, d, lagrangian_gram_vars, verified_gram_vars,\
-            separating_plane_vars = dut.GenerateTuplesForBilinearAlternation(
+            separating_plane_vars, separating_plane_lorentz_cone_constraints =\
+            dut.GenerateTuplesForBilinearAlternation(
                 q_star=q_star, filtered_collision_pairs=set(), C_rows=20)
 
-    def construct_initial_cspace_polytope(self, dut):
-        context = self.plant.CreateDefaultContext()
+    def construct_initial_cspace_polytope(self, dut, diagram):
+        diagram_context = diagram.CreateDefaultContext()
+        context = self.plant.GetMyMutableContextFromRoot(diagram_context)
         q_star = np.zeros(7)
 
         # Build a small c-space polytope C*t <= d around q_not_in_collision
@@ -115,25 +123,30 @@ class IiwaCspaceTest(unittest.TestCase):
         return q_star, C, d
 
     def test_construct_lagrangian_program(self):
-        dut = mut.CspaceFreeRegion(self.diagram, self.plant, self.scene_graph,
+        dut = mut.CspaceFreeRegion(self.diagram,
+                                   self.plant,
+                                   self.scene_graph,
                                    mut.SeparatingPlaneOrder.kAffine,
-                                   mut.CspaceRegionType.kGenericPolytope)
+                                   mut.CspaceRegionType.kGenericPolytope,
+                                   separating_polytope_delta=1.)
         q_star = np.zeros(7)
         alternation_tuples, d_minus_Ct, t_lower, t_upper, t_minus_t_lower,\
             t_upper_minus_t, C_var, d_var, lagrangian_gram_vars,\
-            verified_gram_vars, separating_plane_vars =\
+            verified_gram_vars, separating_plane_vars,\
+            separating_plane_lorentz_cone_constraints =\
             dut.GenerateTuplesForBilinearAlternation(
                 q_star=q_star, filtered_collision_pairs=set(), C_rows=24)
 
-        q_star, C, d = self.construct_initial_cspace_polytope(dut)
+        q_star, C, d = self.construct_initial_cspace_polytope(
+            dut, self.diagram)
         P = np.empty((7, 7), dtype=sym.Variable)
         q = np.empty(7, dtype=sym.Variable)
         verification_option = mut.VerificationOption()
         redundant_tighten = 0.5
         prog_lagrangian = dut.ConstructLagrangianProgram(
             alternation_tuples, C, d, lagrangian_gram_vars, verified_gram_vars,
-            separating_plane_vars, t_lower, t_upper, verification_option,
-            redundant_tighten)
+            separating_plane_vars, separating_plane_lorentz_cone_constraints,
+            t_lower, t_upper, verification_option, redundant_tighten)
         P, q = mut.AddInscribedEllipsoid(prog_lagrangian, C, d, t_lower,
                                          t_upper)
         result_lagrangian = mp.Solve(prog_lagrangian)
@@ -147,16 +160,20 @@ class IiwaCspaceTest(unittest.TestCase):
         prog_polytope = dut.ConstructPolytopeProgram(
             alternation_tuples, C_var, d_var, d_minus_Ct,
             lagrangian_gram_var_vals, verified_gram_vars,
-            separating_plane_vars, t_minus_t_lower, t_upper_minus_t,
-            verification_option)
+            separating_plane_vars, separating_plane_lorentz_cone_constraints,
+            t_minus_t_lower, t_upper_minus_t, verification_option)
         result_polytope = mp.Solve(prog_polytope)
         self.assertTrue(result_polytope.is_success())
 
     def test_cspace_polytope_bilinear_alternation(self):
-        dut = mut.CspaceFreeRegion(self.diagram, self.plant, self.scene_graph,
+        dut = mut.CspaceFreeRegion(self.diagram,
+                                   self.plant,
+                                   self.scene_graph,
                                    mut.SeparatingPlaneOrder.kAffine,
-                                   mut.CspaceRegionType.kGenericPolytope)
-        q_star, C_init, d_init = self.construct_initial_cspace_polytope(dut)
+                                   mut.CspaceRegionType.kGenericPolytope,
+                                   separating_polytope_delta=1.)
+        q_star, C_init, d_init = self.construct_initial_cspace_polytope(
+            dut, self.diagram)
         filtered_collision_pairs = set()
         bilinear_alternation_option = mut.BilinearAlternationOption()
         bilinear_alternation_option.max_iters = 2
@@ -170,10 +187,14 @@ class IiwaCspaceTest(unittest.TestCase):
                 q_inner_pts=None, inner_polytope=None)
 
     def test_cspace_polytope_binary_search(self):
-        dut = mut.CspaceFreeRegion(self.diagram, self.plant, self.scene_graph,
+        dut = mut.CspaceFreeRegion(self.diagram,
+                                   self.plant,
+                                   self.scene_graph,
                                    mut.SeparatingPlaneOrder.kAffine,
-                                   mut.CspaceRegionType.kGenericPolytope)
-        q_star, C_init, d_init = self.construct_initial_cspace_polytope(dut)
+                                   mut.CspaceRegionType.kGenericPolytope,
+                                   separating_polytope_delta=1.)
+        q_star, C_init, d_init = self.construct_initial_cspace_polytope(
+            dut, self.diagram)
         filtered_collision_pairs = set()
         binary_search_option = mut.BinarySearchOption()
         binary_search_option.epsilon_max = 1

--- a/multibody/rational_forward_kinematics/BUILD.bazel
+++ b/multibody/rational_forward_kinematics/BUILD.bazel
@@ -27,7 +27,7 @@ drake_cc_package_library(
     name = "rational_forward_kinematics",
     visibility = ["//visibility:public"],
     deps = [
-        ":convex_geometry",
+        ":collision_geometry",
         ":cspace_free_region",
         ":generate_monomial_basis_util",
         ":plane_side",
@@ -80,9 +80,26 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "collision_geometry",
+    srcs = ["collision_geometry.cc"],
+    hdrs = ["collision_geometry.h"],
+    deps = [
+        ":plane_side",
+        "//geometry:geometry_ids",
+        "//geometry/optimization:convex_set",
+        "//multibody/tree:multibody_tree_indexes",
+    ],
+)
+
+drake_cc_library(
     name = "convex_geometry",
     srcs = ["convex_geometry.cc"],
     hdrs = ["convex_geometry.h"],
+    tags = [
+        # Don't add this library to "rational_forward_kinematics", as this
+        # library will be replaced by collision_geometry
+        "exclude_from_package",
+    ],
     deps = [
         ":plane_side",
         "//geometry:geometry_ids",
@@ -101,7 +118,7 @@ drake_cc_library(
         "cspace_free_region.h",
     ],
     deps = [
-        ":convex_geometry",
+        ":collision_geometry",
         ":generate_monomial_basis_util",
         ":plane_side",
         ":rational_forward_kinematics_core",
@@ -199,9 +216,13 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "cspace_free_region_test",
     timeout = "long",
+    data = [
+        "//geometry:test_obj_files",
+    ],
     deps = [
         ":cspace_free_region",
         ":rational_forward_kinematics_test_utilities2",
+        "//common:find_resource",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:symbolic_test_util",
         "//multibody/inverse_kinematics",

--- a/multibody/rational_forward_kinematics/collision_geometry.cc
+++ b/multibody/rational_forward_kinematics/collision_geometry.cc
@@ -1,0 +1,69 @@
+#include "drake/multibody/rational_forward_kinematics/collision_geometry.h"
+
+#include <vector>
+
+#include <libqhullcpp/Qhull.h>
+
+#include "drake/geometry/read_obj.h"
+
+namespace drake {
+namespace multibody {
+CollisionGeometry::CollisionGeometry(CollisionGeometryType type,
+                                     const geometry::Shape* geometry,
+                                     multibody::BodyIndex body_index,
+                                     geometry::GeometryId id,
+                                     math::RigidTransformd X_BG)
+    : type_{type},
+      geometry_{std::move(geometry)},
+      body_index_{body_index},
+      id_{id},
+      X_BG_{std::move(X_BG)} {}
+
+Eigen::Matrix3Xd GetVertices(const geometry::Shape& shape) {
+  if (dynamic_cast<const geometry::Box*>(&shape) != nullptr) {
+    const auto* box = dynamic_cast<const geometry::Box*>(&shape);
+    Eigen::Matrix<double, 3, 8> vertices;
+    // clang-format off
+    vertices << -1, 1, 1, -1, -1, 1, 1, -1,
+                1, 1, -1, -1, -1, -1, 1, 1,
+                -1, -1, -1, -1, 1, 1, 1, 1;
+    // clang-format on
+    vertices.row(0) *= box->width() / 2;
+    vertices.row(1) *= box->depth() / 2;
+    vertices.row(2) *= box->height() / 2;
+    return vertices;
+  } else if (dynamic_cast<const geometry::Convex*>(&shape) != nullptr) {
+    const auto* convex = dynamic_cast<const geometry::Convex*>(&shape);
+    const auto [tinyobj_vertices, faces, num_faces] =
+        geometry::internal::ReadObjFile(convex->filename(), convex->scale(),
+                                        false /* triangulate */);
+    unused(faces);
+    unused(num_faces);
+    orgQhull::Qhull qhull;
+    const int dim = 3;
+    std::vector<double> tinyobj_vertices_flat(tinyobj_vertices->size() * dim);
+    for (int i = 0; i < static_cast<int>(tinyobj_vertices->size()); ++i) {
+      for (int j = 0; j < dim; ++j) {
+        tinyobj_vertices_flat[dim * i + j] = (*tinyobj_vertices)[i](j);
+      }
+    }
+    qhull.runQhull("", dim, tinyobj_vertices->size(),
+                   tinyobj_vertices_flat.data(), "");
+    if (qhull.qhullStatus() != 0) {
+      throw std::runtime_error(
+          fmt::format("Qhull terminated with status {} and  message:\n{}",
+                      qhull.qhullStatus(), qhull.qhullMessage()));
+    }
+    Eigen::Matrix3Xd vertices(3, qhull.vertexCount());
+    int vertex_count = 0;
+    for (const auto& qhull_vertex : qhull.vertexList()) {
+      vertices.col(vertex_count++) = Eigen::Map<Eigen::Vector3d>(
+          qhull_vertex.point().toStdVector().data());
+    }
+    return vertices;
+  } else {
+    throw std::invalid_argument("GetVertices() only works for Box and Convex");
+  }
+}
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/rational_forward_kinematics/collision_geometry.h
+++ b/multibody/rational_forward_kinematics/collision_geometry.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/optimization/convex_set.h"
+#include "drake/multibody/rational_forward_kinematics/plane_side.h"
+#include "drake/multibody/tree/multibody_tree_indexes.h"
+
+namespace drake {
+namespace multibody {
+enum class CollisionGeometryType {
+  kPolytope,
+  kSphere,
+  kCapsule,
+};
+
+class CollisionGeometry {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(CollisionGeometry)
+
+  /**
+   * @param X_BG The relative pose of the geometry on the frame.
+   */
+  CollisionGeometry(CollisionGeometryType type, const geometry::Shape* geometry,
+                    multibody::BodyIndex body_index, geometry::GeometryId id,
+                    math::RigidTransformd X_BG);
+
+  CollisionGeometryType type() const { return type_; }
+
+  const geometry::Shape& geometry() const { return *geometry_; }
+
+  multibody::BodyIndex body_index() const { return body_index_; }
+
+  geometry::GeometryId id() const { return id_; }
+
+  const math::RigidTransformd& X_BG() const { return X_BG_; }
+
+ private:
+  CollisionGeometryType type_;
+  const geometry::Shape* geometry_;
+  multibody::BodyIndex body_index_;
+  geometry::GeometryId id_;
+  math::RigidTransformd X_BG_;
+};
+
+Eigen::Matrix3Xd GetVertices(const geometry::Shape& shape);
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/rational_forward_kinematics/cspace_free_region.cc
+++ b/multibody/rational_forward_kinematics/cspace_free_region.cc
@@ -3,7 +3,10 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <fstream>
 #include <future>
+#include <iomanip>
+#include <iostream>
 #include <limits>
 #include <list>
 #include <optional>
@@ -13,6 +16,7 @@
 #include <libqhullcpp/Qhull.h>
 
 #include "drake/geometry/optimization/vpolytope.h"
+#include "drake/multibody/rational_forward_kinematics/collision_geometry.h"
 #include "drake/multibody/rational_forward_kinematics/generate_monomial_basis_util.h"
 #include "drake/multibody/rational_forward_kinematics/rational_forward_kinematics_internal.h"
 #include "drake/multibody/rational_forward_kinematics/redundant_inequality_pruning.h"
@@ -55,7 +59,7 @@ struct DirectedKinematicsChainHash {
 // the expressed body to this link (either the robot link or the obstacle).
 void FindMonomialBasisForPolytopicRegion(
     const RationalForwardKinematics& rational_forward_kinematics,
-    const LinkVertexOnPlaneSideRational& rational,
+    const LinkOnPlaneSideRational& rational,
     std::unordered_map<SortedPair<multibody::BodyIndex>,
                        VectorX<drake::symbolic::Monomial>>*
         map_chain_to_monomial_basis,
@@ -63,11 +67,11 @@ void FindMonomialBasisForPolytopicRegion(
   // First check if the monomial basis for this kinematics chain has been
   // computed.
   const SortedPair<multibody::BodyIndex> kinematics_chain(
-      rational.link_polytope->body_index(), rational.expressed_body_index);
+      rational.link_geometry->body_index(), rational.expressed_body_index);
   const auto it = map_chain_to_monomial_basis->find(kinematics_chain);
   if (it == map_chain_to_monomial_basis->end()) {
     const auto t_halfchain = rational_forward_kinematics.FindTOnPath(
-        rational.link_polytope->body_index(), rational.expressed_body_index);
+        rational.link_geometry->body_index(), rational.expressed_body_index);
     if (t_halfchain.rows() > 0) {
       *monomial_basis_halfchain = GenerateMonomialBasisWithOrderUpToOne(
           drake::symbolic::Variables(t_halfchain));
@@ -223,8 +227,8 @@ SeparatingPlane GetSeparatingPlaneSolution(
     a_sol(i) = plane.a(i).EvaluatePartial(env);
   }
   const symbolic::Expression b_sol = plane.b.EvaluatePartial(env);
-  return SeparatingPlane(a_sol, b_sol, plane.positive_side_polytope,
-                         plane.negative_side_polytope, plane.expressed_link,
+  return SeparatingPlane(a_sol, b_sol, plane.positive_side_geometry,
+                         plane.negative_side_geometry, plane.expressed_link,
                          plane.order, plane.decision_variables);
 }
 
@@ -265,32 +269,37 @@ CspaceFreeRegion::CspaceFreeRegion(
     const systems::Diagram<double>& diagram,
     const multibody::MultibodyPlant<double>* plant,
     const geometry::SceneGraph<double>* scene_graph,
-    SeparatingPlaneOrder plane_order, CspaceRegionType cspace_region_type)
+    SeparatingPlaneOrder plane_order, CspaceRegionType cspace_region_type,
+    double separating_polytope_delta)
     : rational_forward_kinematics_(*plant),
       scene_graph_{scene_graph},
-      polytope_geometries_{GetConvexPolytopes(diagram, plant, scene_graph)},
-      plane_order_{plane_order},
-      cspace_region_type_{cspace_region_type} {
+      link_geometries_{GetCollisionGeometries(diagram, plant, scene_graph)},
+      plane_order_for_polytope_{plane_order},
+      cspace_region_type_{cspace_region_type},
+      separating_polytope_delta_{separating_polytope_delta} {
+  DRAKE_DEMAND(separating_polytope_delta_ > 0);
   // Now create the separating planes.
   std::map<SortedPair<BodyIndex>,
-           std::vector<std::pair<const ConvexPolytope*, const ConvexPolytope*>>>
+           std::vector<
+               std::pair<const CollisionGeometry*, const CollisionGeometry*>>>
       collision_pairs;
   int num_collision_pairs = 0;
   const auto& model_inspector = scene_graph->model_inspector();
-  for (const auto& [link1, polytopes1] : polytope_geometries_) {
-    for (const auto& [link2, polytopes2] : polytope_geometries_) {
+  for (const auto& [link1, geometries1] : link_geometries_) {
+    for (const auto& [link2, geometries2] : link_geometries_) {
       if (link1 < link2) {
         // link_collision_pairs stores all the pair of collision geometry on
         // (link1, link2).
-        std::vector<std::pair<const ConvexPolytope*, const ConvexPolytope*>>
+        std::vector<
+            std::pair<const CollisionGeometry*, const CollisionGeometry*>>
             link_collision_pairs;
         // I need to check if the kinematics chain betwen link 1 and link 2 has
         // length 0.
         std::optional<bool> chain_has_length_zero;
-        for (const auto& polytope1 : polytopes1) {
-          for (const auto& polytope2 : polytopes2) {
-            if (!model_inspector.CollisionFiltered(polytope1.get_id(),
-                                                   polytope2.get_id())) {
+        for (const auto& geometry1 : geometries1) {
+          for (const auto& geometry2 : geometries2) {
+            if (!model_inspector.CollisionFiltered(geometry1->id(),
+                                                   geometry2->id())) {
               if (!chain_has_length_zero.has_value()) {
                 chain_has_length_zero =
                     rational_forward_kinematics_.FindTOnPath(link1, link2)
@@ -303,7 +312,8 @@ CspaceFreeRegion::CspaceFreeRegion(
                 }
               }
               num_collision_pairs++;
-              link_collision_pairs.emplace_back(&polytope1, &polytope2);
+              link_collision_pairs.emplace_back(geometry1.get(),
+                                                geometry2.get());
             }
           }
         }
@@ -321,13 +331,19 @@ CspaceFreeRegion::CspaceFreeRegion(
   // angles.
   std::unordered_map<SortedPair<BodyIndex>, VectorX<symbolic::Variable>>
       map_link_obstacle_to_t;
-  for (const auto& [link_pair, polytope_pairs] : collision_pairs) {
-    for (const auto& polytope_pair : polytope_pairs) {
+  for (const auto& [link_pair, geometry_pairs] : collision_pairs) {
+    for (const auto& geometry_pair : geometry_pairs) {
       Vector3<symbolic::Expression> a;
       symbolic::Expression b;
       const symbolic::Monomial monomial_one{};
       VectorX<symbolic::Variable> plane_decision_vars;
-      if (plane_order_ == SeparatingPlaneOrder::kConstant) {
+      SeparatingPlaneOrder plane_order_geometry_pair =
+          SeparatingPlaneOrder::kConstant;
+      if (geometry_pair.first->type() == CollisionGeometryType::kPolytope &&
+          geometry_pair.second->type() == CollisionGeometryType::kPolytope) {
+        plane_order_geometry_pair = plane_order_for_polytope_;
+      }
+      if (plane_order_geometry_pair == SeparatingPlaneOrder::kConstant) {
         plane_decision_vars.resize(4);
         for (int i = 0; i < 3; ++i) {
           plane_decision_vars(i) = symbolic::Variable(
@@ -337,7 +353,7 @@ CspaceFreeRegion::CspaceFreeRegion(
         }
         a = plane_decision_vars.head<3>().cast<symbolic::Expression>();
         b = plane_decision_vars(3);
-      } else if (plane_order_ == SeparatingPlaneOrder::kAffine) {
+      } else if (plane_order_geometry_pair == SeparatingPlaneOrder::kAffine) {
         VectorX<symbolic::Variable> t_for_plane;
         if (cspace_region_type_ == CspaceRegionType::kGenericPolytope) {
           t_for_plane = rational_forward_kinematics_.t();
@@ -392,19 +408,19 @@ CspaceFreeRegion::CspaceFreeRegion(
         var_count++;
       }
       separating_planes_.emplace_back(
-          a, b, polytope_pair.first, polytope_pair.second,
+          a, b, geometry_pair.first, geometry_pair.second,
           internal::FindBodyInTheMiddleOfChain(*plant, link_pair.first(),
                                                link_pair.second()),
-          plane_order_, plane_decision_vars);
-      map_polytopes_to_separating_planes_.emplace(
-          SortedPair<ConvexGeometry::Id>(polytope_pair.first->get_id(),
-                                         polytope_pair.second->get_id()),
+          plane_order_geometry_pair, plane_decision_vars);
+      map_collisions_to_separating_planes_.emplace(
+          SortedPair<geometry::GeometryId>(geometry_pair.first->id(),
+                                           geometry_pair.second->id()),
           static_cast<int>(separating_planes_.size()) - 1);
     }
   }
 }
 
-std::vector<LinkVertexOnPlaneSideRational>
+std::vector<LinkOnPlaneSideRational>
 CspaceFreeRegion::GenerateLinkOnOneSideOfPlaneRationals(
     const Eigen::Ref<const Eigen::VectorXd>& q_star,
     const CspaceFreeRegion::FilteredCollisionPairs& filtered_collision_pairs)
@@ -413,45 +429,45 @@ CspaceFreeRegion::GenerateLinkOnOneSideOfPlaneRationals(
                      RationalForwardKinematics::Pose<symbolic::Polynomial>,
                      DirectedKinematicsChainHash>
       body_pair_to_X_AB_multilinear;
-  std::vector<LinkVertexOnPlaneSideRational> rationals;
+  std::vector<LinkOnPlaneSideRational> rationals;
   for (const auto& separating_plane : separating_planes_) {
     if (!IsGeometryPairCollisionIgnored(
-            separating_plane.positive_side_polytope->get_id(),
-            separating_plane.negative_side_polytope->get_id(),
+            separating_plane.positive_side_geometry->id(),
+            separating_plane.negative_side_geometry->id(),
             filtered_collision_pairs)) {
-      // First compute X_AB for both side of the polytopes.
+      // First compute X_AB for both side of the geometries.
       for (const PlaneSide plane_side :
            {PlaneSide::kPositive, PlaneSide::kNegative}) {
-        const ConvexPolytope* polytope;
-        const ConvexPolytope* other_side_polytope;
+        const CollisionGeometry* link_geometry;
+        const CollisionGeometry* other_side_geometry;
         if (plane_side == PlaneSide::kPositive) {
-          polytope = separating_plane.positive_side_polytope;
-          other_side_polytope = separating_plane.negative_side_polytope;
+          link_geometry = separating_plane.positive_side_geometry;
+          other_side_geometry = separating_plane.negative_side_geometry;
         } else {
-          polytope = separating_plane.negative_side_polytope;
-          other_side_polytope = separating_plane.positive_side_polytope;
+          link_geometry = separating_plane.negative_side_geometry;
+          other_side_geometry = separating_plane.positive_side_geometry;
         }
         const DirectedKinematicsChain expressed_to_link(
-            separating_plane.expressed_link, polytope->body_index());
+            separating_plane.expressed_link, link_geometry->body_index());
         auto it = body_pair_to_X_AB_multilinear.find(expressed_to_link);
         if (it == body_pair_to_X_AB_multilinear.end()) {
           body_pair_to_X_AB_multilinear.emplace_hint(
               it, expressed_to_link,
               rational_forward_kinematics_.CalcLinkPoseAsMultilinearPolynomial(
-                  q_star, polytope->body_index(),
+                  q_star, link_geometry->body_index(),
                   separating_plane.expressed_link));
         }
         it = body_pair_to_X_AB_multilinear.find(expressed_to_link);
         const RationalForwardKinematics::Pose<symbolic::Polynomial>&
             X_AB_multilinear = it->second;
-        const std::vector<LinkVertexOnPlaneSideRational>
-            rationals_expressed_to_link =
-                GenerateLinkOnOneSideOfPlaneRationalFunction(
-                    rational_forward_kinematics_, polytope, other_side_polytope,
-                    X_AB_multilinear, separating_plane.a, separating_plane.b,
-                    plane_side, separating_plane.order);
+        const std::vector<LinkOnPlaneSideRational> rationals_expressed_to_link =
+            GenerateLinkOnOneSideOfPlaneRationalFunction(
+                rational_forward_kinematics_, link_geometry,
+                other_side_geometry, X_AB_multilinear, separating_plane.a,
+                separating_plane.b, plane_side, separating_plane.order,
+                separating_polytope_delta_);
         // I cannot use "insert" function to append vectors, since
-        // LinkVertexOnPlaneSideRational contains const members, hence it does
+        // LinkOnPlaneSideRational contains const members, hence it does
         // not have an assignment operator.
         std::copy(rationals_expressed_to_link.begin(),
                   rationals_expressed_to_link.end(),
@@ -505,7 +521,7 @@ void ConstructTBoundsPolynomial(
  * @param[out] verified_polynomial p(t) - l_polytope(t)ᵀ(d - C*t) -
  * l_lower(t)ᵀ(t-t_lower) - l_upper(t)ᵀ(t_upper-t)
  */
-void AddNonnegativeConstraintForPolytopeOnOneSideOfPlane(
+void AddNonnegativeConstraintForGeometryOnOneSideOfPlane(
     solvers::MathematicalProgram* prog,
     const symbolic::RationalFunction& polytope_on_one_side_rational,
     const VectorX<symbolic::Polynomial>& d_minus_Ct,
@@ -568,7 +584,7 @@ void AddNonnegativeConstraintForPolytopeOnOneSideOfPlane(
 CspaceFreeRegion::CspacePolytopeProgramReturn
 CspaceFreeRegion::ConstructProgramForCspacePolytope(
     const Eigen::Ref<const Eigen::VectorXd>& q_star,
-    const std::vector<LinkVertexOnPlaneSideRational>& rationals,
+    const std::vector<LinkOnPlaneSideRational>& rationals,
     const Eigen::Ref<const Eigen::MatrixXd>& C,
     const Eigen::Ref<const Eigen::VectorXd>& d,
     const FilteredCollisionPairs& filtered_collision_pairs,
@@ -581,8 +597,8 @@ CspaceFreeRegion::ConstructProgramForCspacePolytope(
   // Add separating planes as decision variables.
   for (const auto& separating_plane : separating_planes_) {
     if (!IsGeometryPairCollisionIgnored(
-            separating_plane.positive_side_polytope->get_id(),
-            separating_plane.negative_side_polytope->get_id(),
+            separating_plane.positive_side_geometry->id(),
+            separating_plane.negative_side_geometry->id(),
             filtered_collision_pairs)) {
       ret.prog->AddDecisionVariables(separating_plane.decision_variables);
     }
@@ -633,7 +649,7 @@ CspaceFreeRegion::ConstructProgramForCspacePolytope(
         &map_chain_to_monomial_basis, &monomial_basis_chain);
     // Now add the constraint that C*t<=d and t_lower <= t <= t_upper implies
     // the rational being nonnegative.
-    AddNonnegativeConstraintForPolytopeOnOneSideOfPlane(
+    AddNonnegativeConstraintForGeometryOnOneSideOfPlane(
         ret.prog.get(), rationals[i].rational, d_minus_Ct_polynomial,
         t_minus_t_lower_poly, t_upper_minus_t_poly, monomial_basis_chain,
         verification_option, t_lower_needs_lagrangian, t_upper_needs_lagrangian,
@@ -646,22 +662,16 @@ CspaceFreeRegion::ConstructProgramForCspacePolytope(
 bool CspaceFreeRegion::IsPostureInCollision(
     const systems::Context<double>& context) const {
   const auto& plant = rational_forward_kinematics_.plant();
-  drake::math::RigidTransform<double> X_WB1;
-  drake::math::RigidTransform<double> X_WB2;
-  const auto& model_inspector = scene_graph_->model_inspector();
-  for (const auto& [link1, polytopes1] : polytope_geometries_) {
-    X_WB1 = plant.EvalBodyPoseInWorld(context, plant.get_body(link1));
-    for (const auto& [link2, polytopes2] : polytope_geometries_) {
-      X_WB2 = plant.EvalBodyPoseInWorld(context, plant.get_body(link2));
-      for (const auto& polytope1 : polytopes1) {
-        for (const auto& polytope2 : polytopes2) {
-          if (!model_inspector.CollisionFiltered(polytope1.get_id(),
-                                                 polytope2.get_id()) &&
-              polytope1.IsInCollision(polytope2, X_WB1, X_WB2)) {
-            return true;
-          }
-        }
-      }
+  const auto& query_port = plant.get_geometry_query_input_port();
+  const auto& query_object =
+      query_port.Eval<geometry::QueryObject<double>>(context);
+  const auto& inspector = scene_graph_->model_inspector();
+  for (const auto& geometry_pair : inspector.GetCollisionCandidates()) {
+    const geometry::SignedDistancePair<double> signed_distance_pair =
+        query_object.ComputeSignedDistancePairClosestPoints(
+            geometry_pair.first, geometry_pair.second);
+    if (signed_distance_pair.distance < 0) {
+      return true;
     }
   }
   return false;
@@ -678,7 +688,10 @@ void CspaceFreeRegion::GenerateTuplesForBilinearAlternation(
     VectorX<symbolic::Variable>* lagrangian_gram_vars,
     VectorX<symbolic::Variable>* verified_gram_vars,
     VectorX<symbolic::Variable>* separating_plane_vars,
-    std::vector<std::vector<int>>* separating_plane_to_tuples) const {
+    std::vector<std::vector<int>>* separating_plane_to_tuples,
+    std::vector<std::vector<solvers::Binding<solvers::LorentzConeConstraint>>>*
+        separating_plane_to_lorentz_cone_constraints) const {
+  DRAKE_DEMAND(separating_plane_to_lorentz_cone_constraints != nullptr);
   // Create variables C and d.
   const auto& t = rational_forward_kinematics_.t();
   C->resize(C_rows, t.rows());
@@ -748,12 +761,12 @@ void CspaceFreeRegion::GenerateTuplesForBilinearAlternation(
         t_lower_lagrangian_gram_lower_start,
         t_upper_lagrangian_gram_lower_start, verified_gram_vars_count,
         monomial_basis_chain);
-    (*separating_plane_to_tuples)
-        [this->map_polytopes_to_separating_planes_.at(
-             SortedPair<geometry::GeometryId>(
-                 rationals[i].link_polytope->get_id(),
-                 rationals[i].other_side_link_polytope->get_id()))]
-            .push_back(alternation_tuples->size() - 1);
+    (*separating_plane_to_tuples)[this->map_collisions_to_separating_planes_.at(
+                                      SortedPair<geometry::GeometryId>(
+                                          rationals[i].link_geometry->id(),
+                                          rationals[i]
+                                              .other_side_link_geometry->id()))]
+        .push_back(alternation_tuples->size() - 1);
     // Each Gram matrix is of size monomial_basis_chain.rows() *
     // (monomial_basis_chain.rows() + 1) / 2. Each rational needs C.rows() + 2 *
     // t.rows() Lagrangians.
@@ -784,6 +797,22 @@ void CspaceFreeRegion::GenerateTuplesForBilinearAlternation(
         separating_plane.decision_variables;
     separating_plane_vars_count += separating_plane.decision_variables.rows();
   }
+  // Set the separating plane lorentz cone constraints.
+  separating_plane_to_lorentz_cone_constraints->clear();
+  separating_plane_to_lorentz_cone_constraints->resize(
+      separating_planes_.size());
+  for (const auto& rational : rationals) {
+    if (!rational.lorentz_cone_constraints.empty()) {
+      const int plane_index = map_collisions_to_separating_planes_.at(
+          SortedPair<geometry::GeometryId>(
+              rational.link_geometry->id(),
+              rational.other_side_link_geometry->id()));
+      (*separating_plane_to_lorentz_cone_constraints)[plane_index].insert(
+          (*separating_plane_to_lorentz_cone_constraints)[plane_index].end(),
+          rational.lorentz_cone_constraints.begin(),
+          rational.lorentz_cone_constraints.end());
+    }
+  }
 }
 
 std::unique_ptr<solvers::MathematicalProgram>
@@ -794,6 +823,8 @@ CspaceFreeRegion::ConstructLagrangianProgram(
     const VectorX<symbolic::Variable>& lagrangian_gram_vars,
     const VectorX<symbolic::Variable>& verified_gram_vars,
     const VectorX<symbolic::Variable>& separating_plane_vars,
+    const std::vector<solvers::Binding<solvers::LorentzConeConstraint>>&
+        separating_plane_lorentz_cone_constraints,
     const Eigen::Ref<const Eigen::VectorXd>& t_lower,
     const Eigen::Ref<const Eigen::VectorXd>& t_upper,
     const VerificationOption& option, std::optional<double> redundant_tighten,
@@ -916,6 +947,10 @@ CspaceFreeRegion::ConstructLagrangianProgram(
       prog->AddLinearEqualityConstraint(item.second, 0);
     }
   }
+  // Now add the Lorentz cone constraints for the separting planes.
+  for (const auto& binding : separating_plane_lorentz_cone_constraints) {
+    prog->AddConstraint(binding);
+  }
   if (P != nullptr && q != nullptr) {
     *P = prog->NewSymmetricContinuousVariables(t.rows(), "P");
     *q = prog->NewContinuousVariables(t.rows(), "q");
@@ -933,6 +968,9 @@ CspaceFreeRegion::ConstructPolytopeProgram(
     const Eigen::VectorXd& lagrangian_gram_var_vals,
     const VectorX<symbolic::Variable>& verified_gram_vars,
     const VectorX<symbolic::Variable>& separating_plane_vars,
+    const std::vector<
+        std::vector<solvers::Binding<solvers::LorentzConeConstraint>>>&
+        separating_plane_to_lorentz_cone_constraints,
     const VectorX<symbolic::Polynomial>& t_minus_t_lower,
     const VectorX<symbolic::Polynomial>& t_upper_minus_t,
     const VerificationOption& option) const {
@@ -1005,6 +1043,12 @@ CspaceFreeRegion::ConstructPolytopeProgram(
                                          verified_polynomial_expected};
     for (const auto& item : poly_diff.monomial_to_coefficient_map()) {
       prog->AddLinearEqualityConstraint(item.second, 0);
+    }
+  }
+  // Add Lorentz cone constraints for separating planes.
+  for (const auto& bindings : separating_plane_to_lorentz_cone_constraints) {
+    for (const auto& binding : bindings) {
+      prog->AddConstraint(binding);
     }
   }
   return prog;
@@ -1113,8 +1157,8 @@ std::vector<bool> IsPlaneActive(
   std::vector<bool> is_plane_active(separating_planes.size(), true);
   for (int i = 0; i < static_cast<int>(separating_planes.size()); ++i) {
     if (filtered_collision_pairs.count(SortedPair<geometry::GeometryId>(
-            separating_planes[i].positive_side_polytope->get_id(),
-            separating_planes[i].negative_side_polytope->get_id())) != 0) {
+            separating_planes[i].positive_side_geometry->id(),
+            separating_planes[i].negative_side_geometry->id())) != 0) {
       is_plane_active[i] = false;
     }
   }
@@ -1133,6 +1177,9 @@ bool FindLagrangianAndSeparatingPlanesSingleThread(
     const VectorX<symbolic::Variable>& lagrangian_gram_vars,
     const VectorX<symbolic::Variable>& verified_gram_vars,
     const VectorX<symbolic::Variable>& separating_plane_vars,
+    const std::vector<
+        std::vector<solvers::Binding<solvers::LorentzConeConstraint>>>&
+        separating_plane_to_lorentz_cone_constraints,
     const Eigen::VectorXd& t_lower, const Eigen::VectorXd& t_upper,
     const VerificationOption& verification_option,
     std::optional<double> redundant_tighten,
@@ -1142,10 +1189,17 @@ bool FindLagrangianAndSeparatingPlanesSingleThread(
     Eigen::VectorXd* verified_gram_var_vals,
     Eigen::VectorXd* separating_plane_var_vals,
     std::vector<SeparatingPlane>* separating_planes_sol) {
+  std::vector<solvers::Binding<solvers::LorentzConeConstraint>>
+      separating_plane_lorentz_cone_constraints;
+  for (const auto& bindings : separating_plane_to_lorentz_cone_constraints) {
+    separating_plane_lorentz_cone_constraints.insert(
+        separating_plane_lorentz_cone_constraints.end(), bindings.begin(),
+        bindings.end());
+  }
   auto prog_lagrangian = cspace_free_region.ConstructLagrangianProgram(
       alternation_tuples, C, d, lagrangian_gram_vars, verified_gram_vars,
-      separating_plane_vars, t_lower, t_upper, verification_option,
-      redundant_tighten, nullptr, nullptr);
+      separating_plane_vars, separating_plane_lorentz_cone_constraints, t_lower,
+      t_upper, verification_option, redundant_tighten, nullptr, nullptr);
   auto result_lagrangian =
       solvers::Solve(*prog_lagrangian, std::nullopt, solver_options);
   if (!result_lagrangian.is_success()) {
@@ -1196,6 +1250,9 @@ bool FindLagrangianAndSeparatingPlanesMultiThread(
     const VectorX<symbolic::Variable>& lagrangian_gram_vars,
     const VectorX<symbolic::Variable>& verified_gram_vars,
     const VectorX<symbolic::Variable>& separating_plane_vars,
+    const std::vector<
+        std::vector<solvers::Binding<solvers::LorentzConeConstraint>>>&
+        separating_plane_to_lorentz_cone_constraints,
     const Eigen::VectorXd& t_lower, const Eigen::VectorXd& t_upper,
     const VerificationOption& verification_option,
     std::optional<double> redundant_tighten,
@@ -1247,9 +1304,11 @@ bool FindLagrangianAndSeparatingPlanesMultiThread(
   // multiplier for a pair of collision geometries.
   auto solve_small_sos = [&cspace_free_region, &alternation_tuples, &C, &d,
                           &lagrangian_gram_vars, &verified_gram_vars,
-                          &separating_plane_vars, &t_lower, &t_upper,
-                          &verification_option, &redundant_tighten,
-                          &solver_options, &separating_plane_to_tuples,
+                          &separating_plane_vars,
+                          &separating_plane_to_lorentz_cone_constraints,
+                          &t_lower, &t_upper, &verification_option,
+                          &redundant_tighten, &solver_options,
+                          &separating_plane_to_tuples,
                           &separating_plane_var_indices,
                           &active_plane_count_to_plane_index,
                           lagrangian_gram_var_vals, separating_planes_sol,
@@ -1266,8 +1325,9 @@ bool FindLagrangianAndSeparatingPlanesMultiThread(
     }
     auto prog = cspace_free_region.ConstructLagrangianProgram(
         plane_tuples, C, d, lagrangian_gram_vars, verified_gram_vars,
-        separating_plane_vars, t_lower, t_upper, verification_option,
-        redundant_tighten, nullptr, nullptr);
+        separating_plane_vars,
+        separating_plane_to_lorentz_cone_constraints[plane_index], t_lower,
+        t_upper, verification_option, redundant_tighten, nullptr, nullptr);
     const auto result = solvers::Solve(*prog, std::nullopt, solver_options);
     is_success[active_plane_count] = result.is_success();
     if (result.is_success()) {
@@ -1399,10 +1459,10 @@ bool FindLagrangianAndSeparatingPlanesMultiThread(
               "({}, {})\n",
               inspector.GetName(
                   cspace_free_region.separating_planes()[plane_index]
-                      .positive_side_polytope->get_id()),
+                      .positive_side_geometry->id()),
               inspector.GetName(
                   cspace_free_region.separating_planes()[plane_index]
-                      .negative_side_polytope->get_id())));
+                      .negative_side_geometry->id())));
         }
       }
 
@@ -1422,6 +1482,9 @@ bool FindLagrangianAndSeparatingPlanes(
     const VectorX<symbolic::Variable>& lagrangian_gram_vars,
     const VectorX<symbolic::Variable>& verified_gram_vars,
     const VectorX<symbolic::Variable>& separating_plane_vars,
+    const std::vector<
+        std::vector<solvers::Binding<solvers::LorentzConeConstraint>>>&
+        separating_plane_to_lorentz_cone_constraints,
     const Eigen::VectorXd& t_lower, const Eigen::VectorXd& t_upper,
     const VerificationOption& verification_option,
     std::optional<double> redundant_tighten,
@@ -1436,7 +1499,8 @@ bool FindLagrangianAndSeparatingPlanes(
   if (num_threads.has_value()) {
     ret_val = FindLagrangianAndSeparatingPlanesMultiThread(
         cspace_free_region, alternation_tuples, C, d, lagrangian_gram_vars,
-        verified_gram_vars, separating_plane_vars, t_lower, t_upper,
+        verified_gram_vars, separating_plane_vars,
+        separating_plane_to_lorentz_cone_constraints, t_lower, t_upper,
         verification_option, redundant_tighten, solver_options, verbose,
         separating_plane_to_tuples, num_threads.value(),
         lagrangian_gram_var_vals, verified_gram_var_vals,
@@ -1456,7 +1520,8 @@ bool FindLagrangianAndSeparatingPlanes(
     }
     ret_val = FindLagrangianAndSeparatingPlanesSingleThread(
         cspace_free_region, alternation_tuples, C, d, lagrangian_gram_vars,
-        verified_gram_vars, separating_plane_vars, t_lower, t_upper,
+        verified_gram_vars, separating_plane_vars,
+        separating_plane_to_lorentz_cone_constraints, t_lower, t_upper,
         verification_option, redundant_tighten, solver_options, verbose,
         is_plane_active, lagrangian_gram_var_vals, verified_gram_var_vals,
         separating_plane_var_vals,
@@ -1518,11 +1583,14 @@ void CspaceFreeRegion::CspacePolytopeBilinearAlternation(
   VectorX<symbolic::Variable> d_var, lagrangian_gram_vars, verified_gram_vars,
       separating_plane_vars;
   std::vector<std::vector<int>> separating_plane_to_tuples;
+  std::vector<std::vector<solvers::Binding<solvers::LorentzConeConstraint>>>
+      separating_plane_to_lorentz_cone_constraints;
   GenerateTuplesForBilinearAlternation(
       q_star, filtered_collision_pairs, C_rows, &alternation_tuples,
       &d_minus_Ct, &t_lower, &t_upper, &t_minus_t_lower, &t_upper_minus_t,
       &C_var, &d_var, &lagrangian_gram_vars, &verified_gram_vars,
-      &separating_plane_vars, &separating_plane_to_tuples);
+      &separating_plane_vars, &separating_plane_to_tuples,
+      &separating_plane_to_lorentz_cone_constraints);
   if (bilinear_alternation_option.compute_polytope_volume) {
     drake::log()->info(
         fmt::format("Polytope volume {}",
@@ -1547,7 +1615,8 @@ void CspaceFreeRegion::CspacePolytopeBilinearAlternation(
     const bool find_lagrangian = internal::FindLagrangianAndSeparatingPlanes(
         *this, alternation_tuples, (cspace_free_region_solution->C),
         (cspace_free_region_solution->d), lagrangian_gram_vars,
-        verified_gram_vars, separating_plane_vars, t_lower, t_upper,
+        verified_gram_vars, separating_plane_vars,
+        separating_plane_to_lorentz_cone_constraints, t_lower, t_upper,
         verification_option, bilinear_alternation_option.redundant_tighten,
         solver_options, bilinear_alternation_option.verbose,
         bilinear_alternation_option.num_threads, separating_plane_to_tuples,
@@ -1583,7 +1652,8 @@ void CspaceFreeRegion::CspacePolytopeBilinearAlternation(
     // Now solve the polytope problem (fix Lagrangian).
     auto prog_polytope = ConstructPolytopeProgram(
         alternation_tuples, C_var, d_var, d_minus_Ct, lagrangian_gram_var_vals,
-        verified_gram_vars, separating_plane_vars, t_minus_t_lower,
+        verified_gram_vars, separating_plane_vars,
+        separating_plane_to_lorentz_cone_constraints, t_minus_t_lower,
         t_upper_minus_t, verification_option);
     // Add the constraint that the polytope contains the ellipsoid
     margin = prog_polytope->NewContinuousVariables(C_var.rows(), "margin");
@@ -1718,11 +1788,14 @@ void CspaceFreeRegion::CspacePolytopeBinarySearch(
   VectorX<symbolic::Variable> d_var, lagrangian_gram_vars, verified_gram_vars,
       separating_plane_vars;
   std::vector<std::vector<int>> separating_plane_to_tuples;
+  std::vector<std::vector<solvers::Binding<solvers::LorentzConeConstraint>>>
+      separating_plane_to_lorentz_cone_constraints;
   GenerateTuplesForBilinearAlternation(
       q_star, filtered_collision_pairs, C_rows, &alternation_tuples,
       &d_minus_Ct, &t_lower, &t_upper, &t_minus_t_lower, &t_upper_minus_t,
       &C_var, &d_var, &lagrangian_gram_vars, &verified_gram_vars,
-      &separating_plane_vars, &separating_plane_to_tuples);
+      &separating_plane_vars, &separating_plane_to_tuples,
+      &separating_plane_to_lorentz_cone_constraints);
   std::optional<Eigen::MatrixXd> t_inner_pts;
   if (q_inner_pts.has_value()) {
     t_inner_pts->resize(q_inner_pts->rows(), q_inner_pts->cols());
@@ -1741,96 +1814,98 @@ void CspaceFreeRegion::CspacePolytopeBinarySearch(
       internal::IsPlaneActive(separating_planes_, filtered_collision_pairs);
   // Checks if C*t<=d, t_lower<=t<=t_upper is collision free.
   // This function will update d_sol when the polytope is collision free.
-  auto is_polytope_collision_free = [this, &alternation_tuples, &C,
-                                     &lagrangian_gram_vars, &verified_gram_vars,
-                                     &separating_plane_vars, &t_lower, &t_upper,
-                                     &binary_search_option,
-                                     &verification_option, &solver_options,
-                                     &C_var, &d_var, &d_minus_Ct,
-                                     &t_minus_t_lower, &t_upper_minus_t,
-                                     &t_inner_pts, &inner_polytope, &d_max,
-                                     &is_plane_active,
-                                     &separating_plane_to_tuples,
-                                     cspace_free_region_solution](
-                                        const Eigen::VectorXd& d) {
-    const double redundant_tighten = 0.;
-    double ellipsoid_cost_val;
+  auto is_polytope_collision_free =
+      [this, &alternation_tuples, &C, &lagrangian_gram_vars,
+       &verified_gram_vars, &separating_plane_vars,
+       &separating_plane_to_lorentz_cone_constraints, &t_lower, &t_upper,
+       &binary_search_option, &verification_option, &solver_options, &C_var,
+       &d_var, &d_minus_Ct, &t_minus_t_lower, &t_upper_minus_t, &t_inner_pts,
+       &inner_polytope, &d_max, &is_plane_active, &separating_plane_to_tuples,
+       cspace_free_region_solution](const Eigen::VectorXd& d) {
+        const double redundant_tighten = 0.;
+        double ellipsoid_cost_val;
 
-    Eigen::VectorXd lagrangian_gram_var_vals, verified_gram_var_vals,
-        separating_plane_var_vals;
-    const bool is_success = internal::FindLagrangianAndSeparatingPlanes(
-        *this, alternation_tuples, C, d, lagrangian_gram_vars,
-        verified_gram_vars, separating_plane_vars, t_lower, t_upper,
-        verification_option, redundant_tighten, solver_options,
-        binary_search_option.verbose, binary_search_option.num_threads,
-        separating_plane_to_tuples, &lagrangian_gram_var_vals,
-        &verified_gram_var_vals, &separating_plane_var_vals,
-        cspace_free_region_solution);
-    if (is_success) {
-      (cspace_free_region_solution->d) = d;
-
-      FindLargestInscribedEllipsoid(
-          (cspace_free_region_solution->C), (cspace_free_region_solution->d),
-          t_lower, t_upper, binary_search_option.lagrangian_backoff_scale,
-          binary_search_option.ellipsoid_volume, solver_options,
-          binary_search_option.verbose,
-          &(cspace_free_region_solution->P),
-          &(cspace_free_region_solution->q), &ellipsoid_cost_val);
-      if (binary_search_option.search_d) {
-        // Now fix the Lagrangian and C, and search for d.
-        auto prog_polytope = this->ConstructPolytopeProgram(
-            alternation_tuples, C_var, d_var, d_minus_Ct,
-            lagrangian_gram_var_vals, verified_gram_vars, separating_plane_vars,
-            t_minus_t_lower, t_upper_minus_t, verification_option);
-        // Calling AddBoundingBoxConstraint(C, C, C_var) for matrix C and
-        // C_var might have problem, see Drake issue #16421
-        prog_polytope->AddBoundingBoxConstraint(
-            Eigen::Map<const Eigen::VectorXd>(C.data(), C.rows() * C.cols()),
-            Eigen::Map<const Eigen::VectorXd>(C.data(), C.rows() * C.cols()),
-            Eigen::Map<const VectorX<symbolic::Variable>>(C_var.data(),
-                                                          C.rows() * C.cols()));
-        // d <= d_var <= d_max
-        prog_polytope->AddBoundingBoxConstraint(d, d_max, d_var);
-        if (t_inner_pts.has_value()) {
-          AddCspacePolytopeContainment(prog_polytope.get(), C_var, d_var,
-                                       t_inner_pts.value());
-        }
-        if (inner_polytope.has_value()) {
-          AddCspacePolytopeContainment(
-              prog_polytope.get(), C_var, d_var, inner_polytope->first,
-              inner_polytope->second, t_lower, t_upper);
-        }
-        // maximize d_var.
-        prog_polytope->AddLinearCost(-Eigen::VectorXd::Ones(d_var.rows()), 0,
-                                     d_var);
-        const auto result_polytope =
-            solvers::Solve(*prog_polytope, std::nullopt, solver_options);
-        drake::log()->info(fmt::format("search d is successful = {}",
-                                       result_polytope.is_success()));
-        if (result_polytope.is_success()) {
-          (cspace_free_region_solution->d) = result_polytope.GetSolution(d_var);
-          (cspace_free_region_solution->separating_planes) =
-              GetSeparatingPlanesSolution(*this, is_plane_active,
-                                          result_polytope);
+        Eigen::VectorXd lagrangian_gram_var_vals, verified_gram_var_vals,
+            separating_plane_var_vals;
+        const bool is_success = internal::FindLagrangianAndSeparatingPlanes(
+            *this, alternation_tuples, C, d, lagrangian_gram_vars,
+            verified_gram_vars, separating_plane_vars,
+            separating_plane_to_lorentz_cone_constraints, t_lower, t_upper,
+            verification_option, redundant_tighten, solver_options,
+            binary_search_option.verbose, binary_search_option.num_threads,
+            separating_plane_to_tuples, &lagrangian_gram_var_vals,
+            &verified_gram_var_vals, &separating_plane_var_vals,
+            cspace_free_region_solution);
+        if (is_success) {
+          (cspace_free_region_solution->d) = d;
 
           FindLargestInscribedEllipsoid(
               (cspace_free_region_solution->C),
               (cspace_free_region_solution->d), t_lower, t_upper,
               binary_search_option.lagrangian_backoff_scale,
               binary_search_option.ellipsoid_volume, solver_options,
-              binary_search_option.verbose,
-              &(cspace_free_region_solution->P),
+              binary_search_option.verbose, &(cspace_free_region_solution->P),
               &(cspace_free_region_solution->q), &ellipsoid_cost_val);
+          if (binary_search_option.search_d) {
+            // Now fix the Lagrangian and C, and search for d.
+            auto prog_polytope = this->ConstructPolytopeProgram(
+                alternation_tuples, C_var, d_var, d_minus_Ct,
+                lagrangian_gram_var_vals, verified_gram_vars,
+                separating_plane_vars,
+                separating_plane_to_lorentz_cone_constraints, t_minus_t_lower,
+                t_upper_minus_t, verification_option);
+            // Calling AddBoundingBoxConstraint(C, C, C_var) for matrix C and
+            // C_var might have problem, see Drake issue #16421
+            prog_polytope->AddBoundingBoxConstraint(
+                Eigen::Map<const Eigen::VectorXd>(C.data(),
+                                                  C.rows() * C.cols()),
+                Eigen::Map<const Eigen::VectorXd>(C.data(),
+                                                  C.rows() * C.cols()),
+                Eigen::Map<const VectorX<symbolic::Variable>>(
+                    C_var.data(), C.rows() * C.cols()));
+            // d <= d_var <= d_max
+            prog_polytope->AddBoundingBoxConstraint(d, d_max, d_var);
+            if (t_inner_pts.has_value()) {
+              AddCspacePolytopeContainment(prog_polytope.get(), C_var, d_var,
+                                           t_inner_pts.value());
+            }
+            if (inner_polytope.has_value()) {
+              AddCspacePolytopeContainment(
+                  prog_polytope.get(), C_var, d_var, inner_polytope->first,
+                  inner_polytope->second, t_lower, t_upper);
+            }
+            // maximize d_var.
+            prog_polytope->AddLinearCost(-Eigen::VectorXd::Ones(d_var.rows()),
+                                         0, d_var);
+            const auto result_polytope =
+                solvers::Solve(*prog_polytope, std::nullopt, solver_options);
+            drake::log()->info(fmt::format("search d is successful = {}",
+                                           result_polytope.is_success()));
+            if (result_polytope.is_success()) {
+              (cspace_free_region_solution->d) =
+                  result_polytope.GetSolution(d_var);
+              (cspace_free_region_solution->separating_planes) =
+                  GetSeparatingPlanesSolution(*this, is_plane_active,
+                                              result_polytope);
+
+              FindLargestInscribedEllipsoid(
+                  (cspace_free_region_solution->C),
+                  (cspace_free_region_solution->d), t_lower, t_upper,
+                  binary_search_option.lagrangian_backoff_scale,
+                  binary_search_option.ellipsoid_volume, solver_options,
+                  binary_search_option.verbose,
+                  &(cspace_free_region_solution->P),
+                  &(cspace_free_region_solution->q), &ellipsoid_cost_val);
+            }
+          }
         }
-      }
-    }
-    if (binary_search_option.compute_polytope_volume) {
-      drake::log()->info(
-          fmt::format("C-space polytope volume {}",
-                      CalcCspacePolytopeVolume(C, d, t_lower, t_upper)));
-    }
-    return is_success;
-  };
+        if (binary_search_option.compute_polytope_volume) {
+          drake::log()->info(
+              fmt::format("C-space polytope volume {}",
+                          CalcCspacePolytopeVolume(C, d, t_lower, t_upper)));
+        }
+        return is_success;
+      };
 
   if (is_polytope_collision_free(
           d_without_epsilon +
@@ -1888,17 +1963,42 @@ void CspaceFreeRegion::CspacePolytopeBinarySearch(
       &(cspace_free_region_solution->q), &ellipsoid_cost_val);
 }
 
-std::vector<LinkVertexOnPlaneSideRational>
+// Get the Lorentz cone constraint for |a|<=1
+std::vector<solvers::Binding<solvers::LorentzConeConstraint>>
+GetNormLessThan1Constraint(const Vector3<symbolic::Expression>& a_A) {
+  Eigen::Matrix<double, 4, 3> A_lorentz = Eigen::Matrix<double, 4, 3>::Zero();
+  A_lorentz.bottomRows<3>() = Eigen::Matrix3d::Identity();
+  const Eigen::Vector4d b_lorentz(1, 0, 0, 0);
+  Vector3<symbolic::Variable> a_var;
+  for (int i = 0; i < 3; ++i) {
+    DRAKE_DEMAND(symbolic::is_variable(a_A(i)));
+    a_var(i) = *a_A(i).GetVariables().begin();
+  }
+  std::vector<solvers::Binding<solvers::LorentzConeConstraint>>
+      lorentz_cone_constraints;
+  lorentz_cone_constraints.emplace_back(
+      std::make_shared<solvers::LorentzConeConstraint>(A_lorentz, b_lorentz),
+      a_var);
+  return lorentz_cone_constraints;
+}
+
+std::vector<LinkOnPlaneSideRational>
 GenerateLinkOnOneSideOfPlaneRationalFunction(
     const RationalForwardKinematics& rational_forward_kinematics,
-    const ConvexPolytope* polytope, const ConvexPolytope* other_side_polytope,
+    const CollisionGeometry* link_geometry,
+    const CollisionGeometry* other_side_geometry,
     const RationalForwardKinematics::Pose<symbolic::Polynomial>&
         X_AB_multilinear,
     const drake::Vector3<symbolic::Expression>& a_A,
     const symbolic::Expression& b, PlaneSide plane_side,
-    SeparatingPlaneOrder plane_order) {
-  std::vector<LinkVertexOnPlaneSideRational> rational_fun;
-  rational_fun.reserve(polytope->p_BV().cols());
+    SeparatingPlaneOrder plane_order, double separating_polytope_delta) {
+  std::vector<LinkOnPlaneSideRational> rational_fun;
+  double separating_delta = 0;
+  if (link_geometry->type() == CollisionGeometryType::kPolytope &&
+      other_side_geometry->type() == CollisionGeometryType::kPolytope) {
+    separating_delta = separating_polytope_delta;
+  }
+
   const symbolic::Monomial monomial_one{};
   // a_A and b are not polynomial of sinθ or cosθ.
   Vector3<symbolic::Polynomial> a_A_poly;
@@ -1906,39 +2006,109 @@ GenerateLinkOnOneSideOfPlaneRationalFunction(
     a_A_poly(i) = symbolic::Polynomial({{monomial_one, a_A(i)}});
   }
   const symbolic::Polynomial b_poly({{monomial_one, b}});
-  for (int i = 0; i < polytope->p_BV().cols(); ++i) {
-    // Step 1: Compute vertex position.
-    const Vector3<drake::symbolic::Polynomial> p_AVi =
-        X_AB_multilinear.p_AB + X_AB_multilinear.R_AB * polytope->p_BV().col(i);
 
-    // Step 2: Compute a_A.dot(p_AVi) + b
-    const drake::symbolic::Polynomial point_on_hyperplane_side =
-        a_A_poly.dot(p_AVi) + b_poly;
+  // Compute the rational for a.dot(p_AQ)+b-offset on the positive side, and
+  // -offset - a.dot(p_AQ)-b on the negative side, add this rational to
+  // rational_fun.
+  auto compute_rational =
+      [&rational_fun, &X_AB_multilinear, &a_A_poly, &b_poly,
+       &rational_forward_kinematics, plane_side, &a_A, &b, link_geometry,
+       other_side_geometry, plane_order](
+          const Eigen::Vector3d& p_BQ, double offset,
+          const std::vector<solvers::Binding<solvers::LorentzConeConstraint>>&
+              lorentz_cone_constraints) {
+        // Step 1: Compute p_AQ.
+        const Vector3<drake::symbolic::Polynomial> p_AQ =
+            X_AB_multilinear.p_AB + X_AB_multilinear.R_AB * p_BQ;
 
-    // Step 3: Convert the multilinear polynomial to rational function.
-    rational_fun.emplace_back(
-        rational_forward_kinematics
-            .ConvertMultilinearPolynomialToRationalFunction(
-                plane_side == PlaneSide::kPositive
-                    ? point_on_hyperplane_side - 1
-                    : -1 - point_on_hyperplane_side),
-        polytope, X_AB_multilinear.frame_A_index, other_side_polytope, a_A, b,
-        plane_side, plane_order);
+        // Step 2: Compute a_A.dot(p_AQ) + b
+        const drake::symbolic::Polynomial point_on_hyperplane_side =
+            a_A_poly.dot(p_AQ) + b_poly;
+
+        // Step 3: Convert the multilinear polynomial to rational function.
+        rational_fun.emplace_back(
+            rational_forward_kinematics
+                .ConvertMultilinearPolynomialToRationalFunction(
+                    plane_side == PlaneSide::kPositive
+                        ? point_on_hyperplane_side - offset
+                        : -offset - point_on_hyperplane_side),
+            link_geometry, X_AB_multilinear.frame_A_index, other_side_geometry,
+            a_A, b, plane_side, plane_order, lorentz_cone_constraints);
+      };
+
+  switch (link_geometry->type()) {
+    case CollisionGeometryType::kPolytope: {
+      // TODO(hongkai.dai): cache the map from geometry_id to vertices since
+      // getting the vertices might be expensive.
+      const Eigen::Matrix3Xd p_BV =
+          link_geometry->X_BG() * GetVertices(link_geometry->geometry());
+      rational_fun.reserve(p_BV.cols());
+      for (int i = 0; i < p_BV.cols(); ++i) {
+        compute_rational(p_BV.col(i), separating_delta, {});
+      }
+      break;
+    }
+    case CollisionGeometryType::kSphere: {
+      // We will generate the rational for
+      // aᵀc + b − r (positive side) or -r − b − aᵀc(negative side)
+      // where c is the center of the sphere, r is the radius of the sphere.
+      // Additionally we will need to add the constraint |a|≤1 as a
+      // second-order cone constraint.
+      const auto link_sphere =
+          dynamic_cast<const geometry::Sphere*>(&link_geometry->geometry());
+      rational_fun.reserve(1);
+      const double radius = link_sphere->radius();
+      DRAKE_DEMAND(plane_order == SeparatingPlaneOrder::kConstant);
+      compute_rational(link_geometry->X_BG().translation(), radius,
+                       GetNormLessThan1Constraint(a_A));
+      break;
+    }
+    case CollisionGeometryType::kCapsule: {
+      // We will generate the rational for
+      // aᵀc₁ + b − r, aᵀc₂ + b − r (positive side) or -r − b − aᵀc₁, -r − b −
+      // aᵀc₂ (negative side) where c₁, c₂ are the centers of the capsule
+      // spheres, r is the radius of the capsule. Additionally we will need to
+      // add the constraint |a|≤1 as a second-order cone constraint.
+      const auto link_capsule =
+          dynamic_cast<const geometry::Capsule*>(&link_geometry->geometry());
+      rational_fun.reserve(2);
+      Eigen::Matrix<double, 3, 2> p_BC;
+      p_BC.col(0) = link_geometry->X_BG() *
+                    Eigen::Vector3d(0, 0, -link_capsule->length() / 2);
+      p_BC.col(1) = link_geometry->X_BG() *
+                    Eigen::Vector3d(0, 0, link_capsule->length() / 2);
+      for (int i = 0; i < 2; ++i) {
+        DRAKE_DEMAND(plane_order == SeparatingPlaneOrder::kConstant);
+        std::vector<solvers::Binding<solvers::LorentzConeConstraint>>
+            lorentz_cone_constraints;
+        if (i == 0) {
+          // We only need to impose the Lorentz cone constraint |a|<=1 for
+          // once, no need to do that for both spheres on the capsule.
+          lorentz_cone_constraints = GetNormLessThan1Constraint(a_A);
+        }
+        compute_rational(p_BC.col(i), link_capsule->radius(),
+                         lorentz_cone_constraints);
+      }
+      break;
+    }
+    default: {
+      throw std::runtime_error("Not implemented yet");
+    }
   }
   return rational_fun;
 }
 
 bool IsGeometryPairCollisionIgnored(
-    const SortedPair<ConvexGeometry::Id>& geometry_pair,
+    const SortedPair<geometry::GeometryId>& geometry_pair,
     const CspaceFreeRegion::FilteredCollisionPairs& filtered_collision_pairs) {
   return filtered_collision_pairs.count(geometry_pair) > 0;
 }
 
 bool IsGeometryPairCollisionIgnored(
-    ConvexGeometry::Id id1, ConvexGeometry::Id id2,
+    geometry::GeometryId id1, geometry::GeometryId id2,
     const CspaceFreeRegion::FilteredCollisionPairs& filtered_collision_pairs) {
   return IsGeometryPairCollisionIgnored(
-      drake::SortedPair<ConvexGeometry::Id>(id1, id2),
+      drake::SortedPair<geometry::GeometryId>(id1, id2),
       filtered_collision_pairs);
 }
 
@@ -1947,7 +2117,8 @@ void ComputeBoundsOnT(const Eigen::Ref<const Eigen::VectorXd>& q_star,
                       const Eigen::Ref<const Eigen::VectorXd>& q_upper,
                       Eigen::VectorXd* t_lower, Eigen::VectorXd* t_upper) {
   DRAKE_DEMAND((q_upper.array() >= q_lower.array()).all());
-  // Currently I require that q_upper - q_star < pi and q_star - q_lower > -pi.
+  // Currently I require that q_upper - q_star < pi and q_star - q_lower >
+  // -pi.
   DRAKE_DEMAND(((q_upper - q_star).array() < M_PI).all());
   DRAKE_DEMAND(((q_star - q_lower).array() > -M_PI).all());
   *t_lower = ((q_lower - q_star) / 2).array().tan();
@@ -2105,9 +2276,9 @@ void AddOuterPolytope(
     const Eigen::Ref<const VectorX<symbolic::Variable>>& d,
     const Eigen::Ref<const VectorX<symbolic::Variable>>& margin) {
   DRAKE_DEMAND(P.rows() == P.cols());
-  // Add the constraint |cᵢᵀP|₂ ≤ dᵢ − cᵢᵀq − δᵢ as a Lorentz cone constraint,
-  // namely [dᵢ − cᵢᵀq − δᵢ, cᵢᵀP] is in the Lorentz cone.
-  // [dᵢ − cᵢᵀq − δᵢ, cᵢᵀP] = A_lorentz1 * [cᵢᵀ, dᵢ, δᵢ] + b_lorentz1
+  // Add the constraint |cᵢᵀP|₂ ≤ dᵢ − cᵢᵀq − δᵢ as a Lorentz cone
+  // constraint, namely [dᵢ − cᵢᵀq − δᵢ, cᵢᵀP] is in the Lorentz cone. [dᵢ
+  // − cᵢᵀq − δᵢ, cᵢᵀP] = A_lorentz1 * [cᵢᵀ, dᵢ, δᵢ] + b_lorentz1
   Eigen::MatrixXd A_lorentz1(P.rows() + 1, 2 + C.cols());
   Eigen::VectorXd b_lorentz1(P.rows() + 1);
   VectorX<symbolic::Variable> lorentz1_vars(2 + C.cols());
@@ -2121,9 +2292,8 @@ void AddOuterPolytope(
     lorentz1_vars << C.row(i).transpose(), d(i), margin(i);
     prog->AddLorentzConeConstraint(A_lorentz1, b_lorentz1, lorentz1_vars);
   }
-  // Add the constraint |cᵢᵀ|₂ ≤ 1 as a Lorentz cone constraint that [1, cᵢᵀ] is
-  // in the Lorentz cone.
-  // [1, cᵢᵀ] = A_lorentz2 * cᵢᵀ + b_lorentz2
+  // Add the constraint |cᵢᵀ|₂ ≤ 1 as a Lorentz cone constraint that [1,
+  // cᵢᵀ] is in the Lorentz cone. [1, cᵢᵀ] = A_lorentz2 * cᵢᵀ + b_lorentz2
   Eigen::MatrixXd A_lorentz2 = Eigen::MatrixXd::Zero(1 + C.cols(), C.cols());
   A_lorentz2.bottomRows(C.cols()) =
       Eigen::MatrixXd::Identity(C.cols(), C.cols());
@@ -2134,11 +2304,11 @@ void AddOuterPolytope(
   }
 }
 
-std::map<BodyIndex, std::vector<ConvexPolytope>> GetConvexPolytopes(
-    const systems::Diagram<double>& diagram,
-    const MultibodyPlant<double>* plant,
-    const geometry::SceneGraph<double>* scene_graph) {
-  std::map<BodyIndex, std::vector<ConvexPolytope>> ret;
+std::map<BodyIndex, std::vector<std::unique_ptr<CollisionGeometry>>>
+GetCollisionGeometries(const systems::Diagram<double>& diagram,
+                       const MultibodyPlant<double>* plant,
+                       const geometry::SceneGraph<double>* scene_graph) {
+  std::map<BodyIndex, std::vector<std::unique_ptr<CollisionGeometry>>> ret;
   // First generate the query object.
   auto diagram_context = diagram.CreateDefaultContext();
   diagram.Publish(*diagram_context);
@@ -2156,17 +2326,43 @@ std::map<BodyIndex, std::vector<ConvexPolytope>> GetConvexPolytopes(
       const auto geometry_ids =
           inspector.GetGeometries(frame_id.value(), geometry::Role::kProximity);
       for (const auto& geometry_id : geometry_ids) {
-        const geometry::optimization::VPolytope v_polytope(
-            query_object, geometry_id, frame_id.value());
-        const ConvexPolytope convex_polytope(body_index, geometry_id,
-                                             v_polytope.vertices());
+        const auto& shape = inspector.GetShape(geometry_id);
+        // Get the pose X_BG;
+        const math::RigidTransformd X_WB =
+            query_object.GetPoseInWorld(*frame_id);
+        const math::RigidTransformd& X_WG =
+            query_object.GetPoseInWorld(geometry_id);
+        const math::RigidTransformd X_BG = X_WB.InvertAndCompose(X_WG);
+        std::unique_ptr<CollisionGeometry> collision_geometry{nullptr};
+        if (dynamic_cast<const geometry::Convex*>(&shape) ||
+            dynamic_cast<const geometry::Box*>(&shape)) {
+          // For a convex mesh or a box, construct a VPolytope.
+          geometry::optimization::VPolytope v_polytope(
+              query_object, geometry_id, frame_id.value());
+          collision_geometry = std::make_unique<CollisionGeometry>(
+              CollisionGeometryType::kPolytope, &shape, body_index, geometry_id,
+              X_BG);
+        } else if (dynamic_cast<const geometry::Sphere*>(&shape)) {
+          collision_geometry = std::make_unique<CollisionGeometry>(
+              CollisionGeometryType::kSphere, &shape, body_index, geometry_id,
+              X_BG);
+        } else if (dynamic_cast<const geometry::Capsule*>(&shape)) {
+          collision_geometry = std::make_unique<CollisionGeometry>(
+              CollisionGeometryType::kCapsule, &shape, body_index, geometry_id,
+              X_BG);
+        } else {
+          throw std::runtime_error(
+              "GetCollisionGeometries: unsupported shape type.");
+        }
+        DRAKE_DEMAND(collision_geometry.get() != nullptr);
+
         auto it = ret.find(body_index);
         if (it == ret.end()) {
-          std::vector<ConvexPolytope> body_polytopes;
-          body_polytopes.push_back(convex_polytope);
-          ret.emplace_hint(it, body_index, body_polytopes);
+          std::vector<std::unique_ptr<CollisionGeometry>> body_geometries;
+          body_geometries.push_back(std::move(collision_geometry));
+          ret.emplace_hint(it, body_index, std::move(body_geometries));
         } else {
-          it->second.push_back(convex_polytope);
+          it->second.push_back(std::move(collision_geometry));
         }
       }
     }
@@ -2183,7 +2379,8 @@ void FindRedundantInequalities(
   C_redundant_indices->clear();
   t_lower_redundant_indices->clear();
   t_upper_redundant_indices->clear();
-  // We aggregate the constraint {C*t<=d, t_lower <= t <= t_upper} as C̅t ≤ d̅
+  // We aggregate the constraint {C*t<=d, t_lower <= t <= t_upper} as C̅t ≤
+  // d̅
   const int nt = t_lower.rows();
   Eigen::MatrixXd C_bar(C.rows() + 2 * nt, nt);
   Eigen::VectorXd d_bar(d.rows() + 2 * nt);
@@ -2287,9 +2484,9 @@ void AddCspacePolytopeContainment(
   Eigen::MatrixXd C_bar;
   Eigen::VectorXd d_bar;
   GetCspacePolytope(C_inner, d_inner, t_lower, t_upper, &C_bar, &d_bar);
-  // According to duality theory, the polytope C*t<=d contains the polytope
-  // C_bar*t <= d_bar if and only if there exists variable λᵢ≥ 0, dᵢ−λᵢᵀd̅≥0,
-  // C̅ᵀλᵢ=cᵢ for every row of C*t<=d.
+  // According to duality theory, the polytope C*t<=d contains the
+  // polytope C_bar*t <= d_bar if and only if there exists variable λᵢ≥ 0,
+  // dᵢ−λᵢᵀd̅≥0, C̅ᵀλᵢ=cᵢ for every row of C*t<=d.
   auto lambda = prog->NewContinuousVariables(C_bar.rows(), C.rows());
   prog->AddBoundingBoxConstraint(0, kInf, lambda);
   // Allocate the memory for the constraint coefficients and variables.
@@ -2348,7 +2545,8 @@ double CalcCspacePolytopeVolume(const Eigen::MatrixXd& C,
   d_bar << d, t_upper, -t_lower;
   const geometry::optimization::HPolyhedron h_poly(C_bar, d_bar);
   const geometry::optimization::VPolytope v_poly(h_poly);
-  // TODO(hongkai.dai) call v_poly.CalcVolume() when Drake PR 16409 is merged.
+  // TODO(hongkai.dai) call v_poly.CalcVolume() when Drake PR 16409 is
+  // merged.
   orgQhull::Qhull qhull;
   qhull.runQhull("", nt, v_poly.vertices().cols(), v_poly.vertices().data(),
                  "");
@@ -2358,6 +2556,93 @@ double CalcCspacePolytopeVolume(const Eigen::MatrixXd& C,
                     qhull.qhullStatus(), qhull.qhullMessage()));
   }
   return qhull.volume();
+}
+
+void WriteCspacePolytopeToFile(const Eigen::Ref<const Eigen::MatrixXd>& C,
+                               const Eigen::Ref<const Eigen::VectorXd>& d,
+                               const Eigen::Ref<const Eigen::VectorXd>& t_lower,
+                               const Eigen::Ref<const Eigen::VectorXd>& t_upper,
+                               const std::string& file_name, int precision) {
+  std::ofstream myfile;
+  myfile.open(file_name, std::ios::out);
+  if (myfile.is_open()) {
+    myfile << fmt::format("{} {}\n", C.rows(), C.cols());
+    for (int i = 0; i < C.rows(); ++i) {
+      for (int j = 0; j < C.cols(); ++j) {
+        myfile << std::setprecision(precision) << C(i, j) << " ";
+      }
+      myfile << "\n";
+    }
+    myfile << "\n";
+    for (int i = 0; i < d.rows(); ++i) {
+      myfile << std::setprecision(precision) << d(i) << " ";
+    }
+    myfile << "\n";
+    for (int i = 0; i < t_lower.rows(); ++i) {
+      myfile << std::setprecision(precision) << t_lower(i) << " ";
+    }
+    myfile << "\n";
+    for (int i = 0; i < t_upper.rows(); ++i) {
+      myfile << std::setprecision(precision) << t_upper(i) << " ";
+    }
+    myfile.close();
+  }
+}
+
+void ReadCspacePolytopeFromFile(const std::string& filename, Eigen::MatrixXd* C,
+                                Eigen::VectorXd* d, Eigen::VectorXd* t_lower,
+                                Eigen::VectorXd* t_upper) {
+  std::ifstream infile;
+  infile.open(filename, std::ios::in);
+  std::string line;
+  if (infile.is_open()) {
+    // Read the size of C, d
+    std::getline(infile, line);
+    std::istringstream ss(line);
+    std::string word;
+    ss >> word;
+    const int C_rows = std::stoi(word);
+    ss >> word;
+    const int C_cols = std::stoi(word);
+    C->resize(C_rows, C_cols);
+    for (int i = 0; i < C_rows; ++i) {
+      std::getline(infile, line);
+      ss = std::istringstream(line);
+      for (int j = 0; j < C_cols; ++j) {
+        ss >> word;
+        (*C)(i, j) = std::stod(word);
+      }
+    }
+    std::getline(infile, line);
+    // get d.
+    std::getline(infile, line);
+    d->resize(C_rows);
+    ss = std::istringstream(line);
+    for (int i = 0; i < C_rows; ++i) {
+      ss >> word;
+      (*d)(i) = std::stod(word);
+    }
+    // get t_lower;
+    std::getline(infile, line);
+    t_lower->resize(C_cols);
+    ss = std::istringstream(line);
+    for (int i = 0; i < C_cols; ++i) {
+      ss >> word;
+      (*t_lower)(i) = std::stod(word);
+    }
+    // get t_upper;
+    std::getline(infile, line);
+    t_upper->resize(C_cols);
+    ss = std::istringstream(line);
+    for (int i = 0; i < C_cols; ++i) {
+      ss >> word;
+      (*t_upper)(i) = std::stod(word);
+    }
+  } else {
+    throw std::runtime_error(
+        fmt::format("Cannot open file {} for c-space polytope.", filename));
+  }
+  infile.close();
 }
 
 // Explicit instantiation.

--- a/multibody/rational_forward_kinematics/cspace_free_region.h
+++ b/multibody/rational_forward_kinematics/cspace_free_region.h
@@ -10,16 +10,18 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/multibody/rational_forward_kinematics/convex_geometry.h"
+#include "drake/multibody/rational_forward_kinematics/collision_geometry.h"
 #include "drake/multibody/rational_forward_kinematics/plane_side.h"
 #include "drake/multibody/rational_forward_kinematics/rational_forward_kinematics.h"
+#include "drake/solvers/constraint.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/mathematical_program_result.h"
 
 /**
  * This file is largely the same as configuration_space_collision_free_region.h.
  * The major differences are
- * 1. The separating hyperplane is parameterized as aᵀx + b ≥ 1 and aᵀx+b ≤ −1
+ * 1. The separating hyperplane is parameterized as aᵀx + b ≥ δ and aᵀx+b ≤ −δ,
+ * where δ is a small positive number.
  * 2. We first focus on the generic polytopic region C*t<=d in the configuration
  * space (we will add the special case for axis-aligned bounding box region
  * t_lower <= t <= t_upper later).
@@ -27,7 +29,7 @@
 
 namespace drake {
 namespace multibody {
-/* The separating plane aᵀx + b ≥ 1, aᵀx+b ≤ −1 has parameters a and b. These
+/* The separating plane aᵀx + b ≥ δ, aᵀx+b ≤ −δ has parameters a and b. These
  * parameters can be a constant of affine function of t.
  */
 enum class SeparatingPlaneOrder {
@@ -36,9 +38,9 @@ enum class SeparatingPlaneOrder {
 };
 
 /**
- * One polytope is on the "positive" side of the separating plane, namely {x|
- * aᵀx + b ≥ 1}, and the other polytope is on the "negative" side of the
- * separating plane, namely {x|aᵀx+b ≤ −1}.
+ * One collision geometry is on the "positive" side of the separating plane,
+ * namely {x| aᵀx + b ≥ δ}, and the other collision geometry is on the
+ * "negative" side of the separating plane, namely {x|aᵀx+b ≤ −δ}.
  */
 struct SeparatingPlane {
  public:
@@ -48,32 +50,31 @@ struct SeparatingPlane {
 
   SeparatingPlane(
       drake::Vector3<symbolic::Expression> m_a, symbolic::Expression m_b,
-      const ConvexPolytope* m_positive_side_polytope,
-      const ConvexPolytope* m_negative_side_polytope,
+      const CollisionGeometry* m_positive_side_geometry,
+      const CollisionGeometry* m_negative_side_geometry,
       multibody::BodyIndex m_expressed_link, SeparatingPlaneOrder m_order,
       const Eigen::Ref<const drake::VectorX<drake::symbolic::Variable>>&
           m_decision_variables)
       : a{std::move(m_a)},
         b{std::move(m_b)},
-        positive_side_polytope{m_positive_side_polytope},
-        negative_side_polytope{m_negative_side_polytope},
+        positive_side_geometry{m_positive_side_geometry},
+        negative_side_geometry{m_negative_side_geometry},
         expressed_link{std::move(m_expressed_link)},
         order{m_order},
         decision_variables{m_decision_variables} {}
 
   Vector3<symbolic::Expression> a;
   symbolic::Expression b;
-  const ConvexPolytope* positive_side_polytope;
-  const ConvexPolytope* negative_side_polytope;
+  const CollisionGeometry* positive_side_geometry;
+  const CollisionGeometry* negative_side_geometry;
   multibody::BodyIndex expressed_link;
   SeparatingPlaneOrder order;
   VectorX<symbolic::Variable> decision_variables;
 };
 
-
 /**
  * We need to verify that C * t <= d implies p(t) >= 0, where p(t) is the
- * numerator of the rational function aᵀx + b - 1 or -1 - aᵀx-b. Namely we need
+ * numerator of the rational function aᵀx + b - δ or -δ - aᵀx-b. Namely we need
  * to verify the non-negativity of the lagrangian polynomial l(t), together with
  * p(t) - l(t)ᵀ(d - C * t). We can choose the type of the non-negative
  * polynomials (sos, dsos, sdsos).
@@ -148,36 +149,43 @@ struct CspaceFreeRegionSolution{
     std::vector<SeparatingPlane> separating_planes;
  };
 
-/**
- * The rational function representing that a link vertex V is on the desired
- * side of the plane. If the link is on the positive side of the plane, then the
- * rational is aᵀx + b - 1, otherwise it is -1 - aᵀx - b
- */
-struct LinkVertexOnPlaneSideRational {
-  LinkVertexOnPlaneSideRational(
-      symbolic::RationalFunction m_rational,
-      const ConvexPolytope* m_link_polytope,
-      multibody::BodyIndex m_expressed_body_index,
-      const ConvexPolytope* m_other_side_link_polytope,
-      Vector3<symbolic::Expression> m_a_A, symbolic::Expression m_b,
-      PlaneSide m_plane_side, SeparatingPlaneOrder m_plane_order)
-      : rational{std::move(m_rational)},
-        link_polytope{m_link_polytope},
-        expressed_body_index{m_expressed_body_index},
-        other_side_link_polytope{m_other_side_link_polytope},
-        a_A{std::move(m_a_A)},
-        b{std::move(m_b)},
-        plane_side{m_plane_side},
-        plane_order{m_plane_order} {}
-  const symbolic::RationalFunction rational;
-  const ConvexPolytope* const link_polytope;
-  const multibody::BodyIndex expressed_body_index;
-  const ConvexPolytope* const other_side_link_polytope;
-  const Vector3<symbolic::Expression> a_A;
-  const symbolic::Expression b;
-  const PlaneSide plane_side;
-  const SeparatingPlaneOrder plane_order;
-};
+ /**
+  * The rational function representing that a link is on the desired
+  * side of the plane. If the link is on the positive side of the plane, then
+  * the rational is aᵀx + b - δ, otherwise it is -δ - aᵀx - b
+  */
+ struct LinkOnPlaneSideRational {
+   LinkOnPlaneSideRational(
+       symbolic::RationalFunction m_rational,
+       const CollisionGeometry* m_link_geometry,
+       multibody::BodyIndex m_expressed_body_index,
+       const CollisionGeometry* m_other_side_link_geometry,
+       Vector3<symbolic::Expression> m_a_A, symbolic::Expression m_b,
+       PlaneSide m_plane_side, SeparatingPlaneOrder m_plane_order,
+       std::vector<solvers::Binding<solvers::LorentzConeConstraint>>
+           m_lorentz_cone_constraints)
+       : rational{std::move(m_rational)},
+         link_geometry{m_link_geometry},
+         expressed_body_index{m_expressed_body_index},
+         other_side_link_geometry{m_other_side_link_geometry},
+         a_A{std::move(m_a_A)},
+         b{std::move(m_b)},
+         plane_side{m_plane_side},
+         plane_order{m_plane_order},
+         lorentz_cone_constraints{std::move(m_lorentz_cone_constraints)} {}
+   const symbolic::RationalFunction rational;
+   const CollisionGeometry* const link_geometry;
+   const multibody::BodyIndex expressed_body_index;
+   const CollisionGeometry* const other_side_link_geometry;
+   const Vector3<symbolic::Expression> a_A;
+   const symbolic::Expression b;
+   const PlaneSide plane_side;
+   const SeparatingPlaneOrder plane_order;
+   // Some geometries (ellipsoid, capsules, etc) require imposing
+   // additional Lorentz cone constraints.
+   const std::vector<solvers::Binding<drake::solvers::LorentzConeConstraint>>
+       lorentz_cone_constraints;
+ };
 
 enum class CspaceRegionType { kGenericPolytope, kAxisAlignedBoundingBox };
 
@@ -193,51 +201,53 @@ enum class EllipsoidVolume { kLog, kNthRoot };
 /**
  * This class tries to find a large convex set in the configuration space, such
  * that this whole convex set is collision free. We assume that the obstacles
- * are unions of polytopes in the workspace, and the robot link poses
+ * are unions of convex geometries in the workspace, and the robot link poses
  * (position/orientation) can be written as rational functions of some
  * variables. Such robot can have only revolute (or prismatic joint). We also
  * suppose that the each link of the robot is represented as a union of
- * polytopes. We will find the convex collision free set in the configuration
- * space through convex optimization.
+ * convex geometries. We will find the convex collision free set in the
+ * configuration space through convex optimization.
  */
 class CspaceFreeRegion {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(CspaceFreeRegion)
 
   using FilteredCollisionPairs =
-      std::unordered_set<drake::SortedPair<ConvexGeometry::Id>>;
+      std::unordered_set<drake::SortedPair<geometry::GeometryId>>;
 
+  /**
+   * @param diagram The diagram containing both the plant and the scene graph.
+   * @param plane_order The order of the plane to separate a pair of polytopic
+   * collision geometries. If either or both of the collision geometry is not a
+   * polyhedron, then we can only use SeparatingPlaneOrder::kConstant for that
+   * plane.
+   * @param separating_polytope_delta δ in the separating plane that separates a
+   * pair of polytopes. This should be a strictly positive number.
+   */
   CspaceFreeRegion(const systems::Diagram<double>& diagram,
                    const multibody::MultibodyPlant<double>* plant,
                    const geometry::SceneGraph<double>* scene_graph,
                    SeparatingPlaneOrder plane_order,
-                   CspaceRegionType cspace_region_type);
+                   CspaceRegionType cspace_region_type,
+                   double separating_polytope_delta = 1.);
 
-  CspaceFreeRegion(const multibody::MultibodyPlant<double>& plant,
-                   const std::vector<const ConvexPolytope*>& link_polytopes,
-                   const std::vector<const ConvexPolytope*>& obstacles,
-                   SeparatingPlaneOrder plane_order,
-                   CspaceRegionType cspace_region_type);
-
-  /** separating_planes()[map_polytopes_to_separating_planes.at(geometry1_id,
+  /** separating_planes()[map_collisions_to_separating_planes.at(geometry1_id,
    * geometry2_id)] is the separating plane that separates geometry1 and
    * geometry 2.
    */
-  const std::unordered_map<SortedPair<ConvexGeometry::Id>, int>&
-  map_polytopes_to_separating_planes() const {
-    return map_polytopes_to_separating_planes_;
+  const std::unordered_map<SortedPair<geometry::GeometryId>, int>&
+  map_collisions_to_separating_planes() const {
+    return map_collisions_to_separating_planes_;
   }
 
   /**
-   * Generate all the rational functions in the form aᵀx + b -1 or -1-aᵀx-b
+   * Generate all the rational functions in the form aᵀx + b -δ or -δ-aᵀx-b
    * whose non-negativity implies that the separating plane aᵀx + b =0 separates
-   * a pair of polytopes.
-   * This function loops over all pair of polytopes between a link and an
-   * obstacle that are not in filtered_collision_pair.
+   * a pair of collision geometries.
+   * This function loops over all pair of collision geometries  that are not in
+   * filtered_collision_pair.
    */
-  // TODO(hongkai.dai): also consider the self-collision pairs.
-  std::vector<LinkVertexOnPlaneSideRational>
-  GenerateLinkOnOneSideOfPlaneRationals(
+  std::vector<LinkOnPlaneSideRational> GenerateLinkOnOneSideOfPlaneRationals(
       const Eigen::Ref<const Eigen::VectorXd>& q_star,
       const CspaceFreeRegion::FilteredCollisionPairs& filtered_collision_pairs)
       const;
@@ -256,7 +266,7 @@ class CspaceFreeRegion {
 
     std::unique_ptr<solvers::MathematicalProgram> prog;
     // polytope_lagrangians has size rationals.size(), namely it is the number
-    // of (link_polytope, obstacle_polytope) pairs. lagrangians[i] has size
+    // of (link_geometry, obstacle_geometry) pairs. lagrangians[i] has size
     // C.rows()
     std::vector<VectorX<symbolic::Polynomial>> polytope_lagrangians;
     // t_lower_lagrangians[i][j] is the lagrangian for t(j) >= t_lower(j) to
@@ -276,7 +286,7 @@ class CspaceFreeRegion {
    */
   CspacePolytopeProgramReturn ConstructProgramForCspacePolytope(
       const Eigen::Ref<const Eigen::VectorXd>& q_star,
-      const std::vector<LinkVertexOnPlaneSideRational>& rationals,
+      const std::vector<LinkOnPlaneSideRational>& rationals,
       const Eigen::Ref<const Eigen::MatrixXd>& C,
       const Eigen::Ref<const Eigen::VectorXd>& d,
       const FilteredCollisionPairs& filtered_collision_pairs,
@@ -284,7 +294,7 @@ class CspaceFreeRegion {
 
   bool IsPostureInCollision(const systems::Context<double>& context) const;
 
-  /** Each tuple corresponds to one rational aᵀx + b - 1 or -1 - aᵀx - b.
+  /** Each tuple corresponds to one rational aᵀx + b - δ or -δ - aᵀx - b.
    * This tuple should be used with GenerateTuplesForBilinearAlternation. To
    * save computation time, this class minimizes using dynamic memory
    * allocation.
@@ -308,7 +318,7 @@ class CspaceFreeRegion {
           monomial_basis{std::move(m_monomial_basis)} {}
 
     // This is the numerator of the rational
-    // aᵀx+b-1 or -1-aᵀx-b
+    // aᵀx+b-δ or -δ-aᵀx-b
     symbolic::Polynomial rational_numerator;
     // lagrangian_gram_var.segment(polytope_lagrangian_gram_lower_start,
     // n(n+1)/2) is the low diagonal entries of the gram matrix in
@@ -349,6 +359,9 @@ class CspaceFreeRegion {
    * based on the separating planes. separating_plane_to_tuples[i] are the
    * indices in alternation_tuples such that these tuples are all for
    * this->separating_planes()[i].
+   * @param[out] separating_plane_lorentz_cone_constraints If the collision
+   * geometry is not a polyhedron, but instead ellipsoid, capsules or cylinders,
+   * we will also impose Lorentz cone constraints.
    */
   void GenerateTuplesForBilinearAlternation(
       const Eigen::Ref<const Eigen::VectorXd>& q_star,
@@ -361,7 +374,10 @@ class CspaceFreeRegion {
       VectorX<symbolic::Variable>* lagrangian_gram_vars,
       VectorX<symbolic::Variable>* verified_gram_vars,
       VectorX<symbolic::Variable>* separating_plane_vars,
-      std::vector<std::vector<int>>* separating_plane_to_tuples) const;
+      std::vector<std::vector<int>>* separating_plane_to_tuples,
+      std::vector<
+          std::vector<solvers::Binding<solvers::LorentzConeConstraint>>>*
+          separating_plane_to_lorentz_cone_constraints) const;
 
   /**
    * Given the C-space free region candidate C*t<=d,
@@ -380,12 +396,14 @@ class CspaceFreeRegion {
    * GenerateTuplesForBilinearAlternation.
    * @param separating_plane_vars computed from
    * GenerateTuplesForBilinearAlternation.
+   * @param separating_plane_lorentz_cone_constraints computed from
+   * GenerateTuplesForBilinearAlternation.
    * @param t_lower The lower bounds of t computed from joint limits.
    * @param t_upper The upper bounds of t computed from joint limits.
    * @param redundant_tighten. We aggregate the constraint {C*t<=d, t_lower <= t
-   * <= t_upper} as C̅t ≤ d̅. A row of C̅t ≤ d̅is regarded as redundant, if the C̅ᵢt
-   * ≤ d̅ᵢ − δ is implied by the rest of the constraint, where
-   * δ=redundant_tighten. If redundant_tighten=std::nullopt, then we don't try
+   * <= t_upper} as C̅t ≤ d̅. A row of C̅t ≤ d̅ is regarded as redundant, if the C̅ᵢt
+   * ≤ d̅ᵢ − Δ is implied by the rest of the constraint, where
+   * Δ=redundant_tighten. If redundant_tighten=std::nullopt, then we don't try
    * to identify the redundant constraints.
    * @param[out] P The inscribed ellipsoid is parameterized as {Py+q | |y|₂ ≤
    * 1}. Set P=nullptr if you don't want the inscribed ellipsoid.
@@ -400,6 +418,8 @@ class CspaceFreeRegion {
       const VectorX<symbolic::Variable>& lagrangian_gram_vars,
       const VectorX<symbolic::Variable>& verified_gram_vars,
       const VectorX<symbolic::Variable>& separating_plane_vars,
+      const std::vector<solvers::Binding<solvers::LorentzConeConstraint>>&
+          separating_plane_lorentz_cone_constraints,
       const Eigen::Ref<const Eigen::VectorXd>& t_lower,
       const Eigen::Ref<const Eigen::VectorXd>& t_upper,
       const VerificationOption& option, std::optional<double> redundant_tighten,
@@ -435,6 +455,9 @@ class CspaceFreeRegion {
       const Eigen::VectorXd& lagrangian_gram_var_vals,
       const VectorX<symbolic::Variable>& verified_gram_vars,
       const VectorX<symbolic::Variable>& separating_plane_vars,
+      const std::vector<
+          std::vector<solvers::Binding<solvers::LorentzConeConstraint>>>&
+          separating_plane_to_lorentz_cone_constraints,
       const VectorX<symbolic::Polynomial>& t_minus_t_lower,
       const VectorX<symbolic::Polynomial>& t_upper_minus_t,
       const VerificationOption& option) const;
@@ -579,51 +602,59 @@ class CspaceFreeRegion {
     return separating_planes_;
   }
 
-  const std::map<multibody::BodyIndex, std::vector<ConvexPolytope>>&
-  polytope_geometries() const {
-    return polytope_geometries_;
+  const std::map<multibody::BodyIndex,
+                 std::vector<std::unique_ptr<CollisionGeometry>>>&
+  link_geometries() const {
+    return link_geometries_;
+  }
+
+  double separating_polytope_delta() const {
+    return separating_polytope_delta_;
   }
 
  private:
   RationalForwardKinematics rational_forward_kinematics_;
   const geometry::SceneGraph<double>* scene_graph_;
-  std::map<multibody::BodyIndex, std::vector<ConvexPolytope>>
-      polytope_geometries_;
+  std::map<multibody::BodyIndex,
+           std::vector<std::unique_ptr<CollisionGeometry>>>
+      link_geometries_;
 
-  SeparatingPlaneOrder plane_order_;
+  SeparatingPlaneOrder plane_order_for_polytope_;
   CspaceRegionType cspace_region_type_;
+  double separating_polytope_delta_;
   std::vector<SeparatingPlane> separating_planes_;
 
   // separating_planes_[(geometry1_id, geometry2_id)] is the separating plane
   // that separates geometry1 and geometry 2.
-  std::unordered_map<SortedPair<ConvexGeometry::Id>, int>
-      map_polytopes_to_separating_planes_;
+  std::unordered_map<SortedPair<geometry::GeometryId>, int>
+      map_collisions_to_separating_planes_;
 };
 
 /**
- * Generate the rational functions a_A.dot(p_AVi(t)) + b(i) - 1 or -1 -
+ * Generate the rational functions a_A.dot(p_AVi(t)) + b(i) - δ or -δ -
  * a_A.dot(p_AVi(t)) - b(i). Which represents that the link (whose vertex Vi has
  * position p_AVi in the frame A) is on the positive (or negative) side of the
  * plane a_A * x + b = 0
  * @param X_AB_multilinear The pose of the link frame B in the expressed body
  * frame A. Note that this pose is a multilinear function of sinθ and cosθ.
  */
-std::vector<LinkVertexOnPlaneSideRational>
+std::vector<LinkOnPlaneSideRational>
 GenerateLinkOnOneSideOfPlaneRationalFunction(
     const RationalForwardKinematics& rational_forward_kinematics,
-    const ConvexPolytope* polytope, const ConvexPolytope* other_side_polytope,
+    const CollisionGeometry* link_geometry,
+    const CollisionGeometry* other_side_geometry,
     const RationalForwardKinematics::Pose<symbolic::Polynomial>&
         X_AB_multilinear,
     const drake::Vector3<symbolic::Expression>& a_A,
     const symbolic::Expression& b, PlaneSide plane_side,
-    SeparatingPlaneOrder plane_order);
+    SeparatingPlaneOrder plane_order, double separating_polytope_delta);
 
 bool IsGeometryPairCollisionIgnored(
-    ConvexGeometry::Id id1, ConvexGeometry::Id id2,
+    geometry::GeometryId id1, geometry::GeometryId id2,
     const CspaceFreeRegion::FilteredCollisionPairs& filtered_collision_pairs);
 
 bool IsGeometryPairCollisionIgnored(
-    const SortedPair<ConvexGeometry::Id>& geometry_pair,
+    const SortedPair<geometry::GeometryId>& geometry_pair,
     const CspaceFreeRegion::FilteredCollisionPairs& filtered_collision_pairs);
 
 void ComputeBoundsOnT(const Eigen::Ref<const Eigen::VectorXd>& q_star,
@@ -731,12 +762,12 @@ void AddOuterPolytope(
 
 /**
  * Given a diagram (which contains the plant and the scene_graph), returns all
- * the convex polytopes.
+ * the collision geometries.
  */
-std::map<BodyIndex, std::vector<ConvexPolytope>> GetConvexPolytopes(
-    const systems::Diagram<double>& diagram,
-    const MultibodyPlant<double>* plant,
-    const geometry::SceneGraph<double>* scene_graph);
+std::map<BodyIndex, std::vector<std::unique_ptr<CollisionGeometry>>>
+GetCollisionGeometries(const systems::Diagram<double>& diagram,
+                       const MultibodyPlant<double>* plant,
+                       const geometry::SceneGraph<double>* scene_graph);
 
 /**
  * Find the redundant constraint in {C*t<=d, t_lower<=t<=t_upper}. We regard a
@@ -812,6 +843,16 @@ void AddCspacePolytopeContainment(
                                               const Eigen::VectorXd& t_lower,
                                               const Eigen::VectorXd& t_upper);
 
+void WriteCspacePolytopeToFile(const Eigen::Ref<const Eigen::MatrixXd>& C,
+                               const Eigen::Ref<const Eigen::VectorXd>& d,
+                               const Eigen::Ref<const Eigen::VectorXd>& t_lower,
+                               const Eigen::Ref<const Eigen::VectorXd>& t_upper,
+                               const std::string& file_name, int precision);
+
+void ReadCspacePolytopeFromFile(const std::string& filename, Eigen::MatrixXd* C,
+                                Eigen::VectorXd* d, Eigen::VectorXd* t_lower,
+                                Eigen::VectorXd* t_upper);
+
 namespace internal {
 // Some of the separating planes will be ignored by filtered_collision_pairs.
 // Returns std::vector<bool> to indicate if each plane is active or not.
@@ -840,6 +881,9 @@ bool FindLagrangianAndSeparatingPlanes(
     const VectorX<symbolic::Variable>& lagrangian_gram_vars,
     const VectorX<symbolic::Variable>& verified_gram_vars,
     const VectorX<symbolic::Variable>& separating_plane_vars,
+    const std::vector<
+        std::vector<solvers::Binding<solvers::LorentzConeConstraint>>>&
+        separating_plane_to_lorentz_cone_constraints,
     const Eigen::VectorXd& t_lower, const Eigen::VectorXd& t_upper,
     const VerificationOption& verification_option,
     std::optional<double> redundant_tighten,

--- a/multibody/rational_forward_kinematics/test/cspace_free_region_test.cc
+++ b/multibody/rational_forward_kinematics/test/cspace_free_region_test.cc
@@ -5,11 +5,16 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/find_resource.h"
+#include "drake/common/temp_directory.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/symbolic_test_util.h"
 #include "drake/geometry/collision_filter_declaration.h"
+#include "drake/geometry/optimization/hyperellipsoid.h"
+#include "drake/geometry/optimization/vpolytope.h"
 #include "drake/multibody/inverse_kinematics/inverse_kinematics.h"
 #include "drake/multibody/plant/coulomb_friction.h"
+#include "drake/multibody/rational_forward_kinematics/collision_geometry.h"
 #include "drake/multibody/rational_forward_kinematics/rational_forward_kinematics.h"
 #include "drake/multibody/rational_forward_kinematics/rational_forward_kinematics_internal.h"
 #include "drake/multibody/rational_forward_kinematics/test/rational_forward_kinematics_test_utilities2.h"
@@ -112,6 +117,70 @@ class IiwaCspaceTest : public ::testing::Test {
   std::vector<geometry::GeometryId> obstacles_id_;
 };
 
+/**
+ * Similar to IiwaCspaceTest but with both polytope and non-polytope collision
+ * geometries.
+ */
+class IiwaNonpolytopeCollisionCspaceTest : public ::testing::Test {
+ public:
+  IiwaNonpolytopeCollisionCspaceTest() {
+    auto iiwa = ConstructIiwaPlant("iiwa14_no_collision.sdf", false);
+    iiwa_link_.resize(iiwa->num_bodies());
+    for (int i = 0; i < 8; ++i) {
+      iiwa_link_[i] =
+          iiwa->GetBodyByName("iiwa_link_" + std::to_string(i)).index();
+    }
+    systems::DiagramBuilder<double> builder;
+    plant_ = builder.AddSystem<MultibodyPlant<double>>(std::move(iiwa));
+    scene_graph_ = builder.AddSystem<geometry::SceneGraph<double>>();
+    plant_->RegisterAsSourceForSceneGraph(scene_graph_);
+
+    builder.Connect(scene_graph_->get_query_output_port(),
+                    plant_->get_geometry_query_input_port());
+
+    builder.Connect(
+        plant_->get_geometry_poses_output_port(),
+        scene_graph_->get_source_pose_port(plant_->get_source_id().value()));
+
+    // Arbitrarily add some collision geometries to links
+    link7_geometries_id_.push_back(plant_->RegisterCollisionGeometry(
+        plant_->get_body(iiwa_link_[7]), {}, geometry::Box(0.1, 0.1, 0.2),
+        "link7_box1", CoulombFriction<double>()));
+    const RigidTransformd X_7P{RotationMatrixd(Eigen::AngleAxisd(
+                                   0.2 * M_PI, Eigen::Vector3d::UnitX())),
+                               {0.1, 0.2, -0.1}};
+    link7_geometries_id_.push_back(plant_->RegisterCollisionGeometry(
+        plant_->get_body(iiwa_link_[7]), X_7P, geometry::Sphere(0.2),
+        "link7_sphere", CoulombFriction<double>()));
+
+    RigidTransformd X_WO = Eigen::Translation3d(0.25, -0.4, 0.05);
+    obstacles_id_.push_back(plant_->RegisterCollisionGeometry(
+        plant_->world_body(), X_WO, geometry::Box(0.1, 0.2, 0.15), "world_box1",
+        CoulombFriction<double>()));
+    link1_geometries_id_.push_back(plant_->RegisterCollisionGeometry(
+        plant_->GetBodyByName("iiwa_link_1"), {}, geometry::Sphere(0.01),
+        "link1_sphere", CoulombFriction<double>()));
+    link2_geometries_id_.push_back(plant_->RegisterCollisionGeometry(
+        plant_->GetBodyByName("iiwa_link_2"),
+        math::RigidTransformd(Eigen::Vector3d(0.05, 0.02, 0.01)),
+        geometry::Capsule(0.05, 0.3), "link2_capsule",
+        CoulombFriction<double>()));
+
+    plant_->Finalize();
+    diagram_ = builder.Build();
+  }
+
+ protected:
+  std::unique_ptr<systems::Diagram<double>> diagram_;
+  MultibodyPlant<double>* plant_;
+  geometry::SceneGraph<double>* scene_graph_;
+  std::vector<BodyIndex> iiwa_link_;
+  std::vector<geometry::GeometryId> link7_geometries_id_;
+  std::vector<geometry::GeometryId> link1_geometries_id_;
+  std::vector<geometry::GeometryId> link2_geometries_id_;
+  std::vector<geometry::GeometryId> obstacles_id_;
+};
+
 // Checks if p is an affine polynomial of x, namely p = a * x + b.
 void CheckIsAffinePolynomial(
     const symbolic::Polynomial& p,
@@ -131,27 +200,27 @@ void TestCspaceFreeRegionConstructor(
     const systems::Diagram<double>& diagram,
     const multibody::MultibodyPlant<double>* plant,
     const geometry::SceneGraph<double>* scene_graph,
-    SeparatingPlaneOrder plane_order, CspaceRegionType cspace_region_type) {
+    SeparatingPlaneOrder plane_order, CspaceRegionType cspace_region_type,
+    double separating_polytope_delta) {
   const CspaceFreeRegion dut(diagram, plant, scene_graph, plane_order,
-                             cspace_region_type);
+                             cspace_region_type, separating_polytope_delta);
   const auto& model_inspector = scene_graph->model_inspector();
   const auto collision_pairs = model_inspector.GetCollisionCandidates();
   EXPECT_EQ(dut.separating_planes().size(), collision_pairs.size());
-  EXPECT_EQ(dut.map_polytopes_to_separating_planes().size(),
+  EXPECT_EQ(dut.map_collisions_to_separating_planes().size(),
             collision_pairs.size());
   // Check that each pair of geometry show up in
   // map_polytopes_to_separating_planes()
   for (const auto& collision_pair : collision_pairs) {
-    auto it = dut.map_polytopes_to_separating_planes().find(
+    auto it = dut.map_collisions_to_separating_planes().find(
         SortedPair<geometry::GeometryId>(collision_pair.first,
                                          collision_pair.second));
-    EXPECT_NE(it, dut.map_polytopes_to_separating_planes().end());
+    EXPECT_NE(it, dut.map_collisions_to_separating_planes().end());
     const SeparatingPlane& separating_plane =
         dut.separating_planes()[it->second];
-    EXPECT_EQ(it->first,
-              SortedPair<geometry::GeometryId>(
-                  separating_plane.positive_side_polytope->get_id(),
-                  separating_plane.negative_side_polytope->get_id()));
+    EXPECT_EQ(it->first, SortedPair<geometry::GeometryId>(
+                             separating_plane.positive_side_geometry->id(),
+                             separating_plane.negative_side_geometry->id()));
     const auto& a = separating_plane.a;
     const auto& b = separating_plane.b;
     const symbolic::Variables t_vars(dut.rational_forward_kinematics().t());
@@ -167,8 +236,8 @@ void TestCspaceFreeRegionConstructor(
         t_for_plane = dut.rational_forward_kinematics().t();
       } else {
         t_for_plane = dut.rational_forward_kinematics().FindTOnPath(
-            separating_plane.positive_side_polytope->body_index(),
-            separating_plane.negative_side_polytope->body_index());
+            separating_plane.positive_side_geometry->body_index(),
+            separating_plane.negative_side_geometry->body_index());
       }
       // Check if a, b are affine function of t_for_plane.
       const symbolic::Variables decision_vars(
@@ -185,52 +254,71 @@ void TestCspaceFreeRegionConstructor(
 }
 
 TEST_F(IiwaCspaceTest, TestConstructor) {
-  TestCspaceFreeRegionConstructor(*diagram_, plant_, scene_graph_,
-                                  SeparatingPlaneOrder::kConstant,
-                                  CspaceRegionType::kGenericPolytope);
+  const double separating_polytope_delta = 0.1;
+  TestCspaceFreeRegionConstructor(
+      *diagram_, plant_, scene_graph_, SeparatingPlaneOrder::kConstant,
+      CspaceRegionType::kGenericPolytope, separating_polytope_delta);
   // Add some collision filters.
   const auto filter_ids = ApplyFilter();
-  TestCspaceFreeRegionConstructor(*diagram_, plant_, scene_graph_,
-                                  SeparatingPlaneOrder::kConstant,
-                                  CspaceRegionType::kGenericPolytope);
+  TestCspaceFreeRegionConstructor(
+      *diagram_, plant_, scene_graph_, SeparatingPlaneOrder::kConstant,
+      CspaceRegionType::kGenericPolytope, separating_polytope_delta);
   for (const auto filter_id : filter_ids) {
     scene_graph_->collision_filter_manager().RemoveDeclaration(filter_id);
   }
   // Test with as axis-aligned bounding box
-  TestCspaceFreeRegionConstructor(*diagram_, plant_, scene_graph_,
-                                  SeparatingPlaneOrder::kConstant,
-                                  CspaceRegionType::kAxisAlignedBoundingBox);
+  TestCspaceFreeRegionConstructor(
+      *diagram_, plant_, scene_graph_, SeparatingPlaneOrder::kConstant,
+      CspaceRegionType::kAxisAlignedBoundingBox, separating_polytope_delta);
+}
+
+// The Lorentz cone constraint is [1; a] in Lorentz cone.
+void CheckRationalLorentzConeConstraint(
+    const solvers::Binding<solvers::LorentzConeConstraint>& binding,
+    const Vector3<symbolic::Expression>& a, double tol) {
+  EXPECT_EQ(binding.variables().rows(), 3);
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_EQ(a(i), symbolic::Expression(binding.variables()(i)));
+  }
+  Eigen::Matrix<double, 4, 3> lorentz_cone_A_expected;
+  lorentz_cone_A_expected.setZero();
+  lorentz_cone_A_expected.bottomRows<3>() = Eigen::Matrix3d::Identity();
+  EXPECT_TRUE(CompareMatrices(lorentz_cone_A_expected,
+                              binding.evaluator()->A_dense(), tol));
+  EXPECT_TRUE(CompareMatrices(Eigen::Vector4d(1, 0, 0, 0),
+                              binding.evaluator()->b(), tol));
 }
 
 void TestGenerateLinkOnOneSideOfPlaneRationalFunction(
     const RationalForwardKinematics& rational_forward_kinematics,
     const SeparatingPlane& separating_plane, PlaneSide plane_side,
-    const Eigen::Ref<const Eigen::VectorXd>& q_star) {
-  const ConvexPolytope* link_polytope;
-  const ConvexPolytope* other_side_polytope;
+    const Eigen::Ref<const Eigen::VectorXd>& q_star,
+    double separating_polytope_delta) {
+  const CollisionGeometry* link_geometry;
+  const CollisionGeometry* other_side_geometry;
   if (plane_side == PlaneSide::kPositive) {
-    link_polytope = separating_plane.positive_side_polytope;
-    other_side_polytope = separating_plane.negative_side_polytope;
+    link_geometry = separating_plane.positive_side_geometry;
+    other_side_geometry = separating_plane.negative_side_geometry;
   } else {
-    link_polytope = separating_plane.negative_side_polytope;
-    other_side_polytope = separating_plane.positive_side_polytope;
+    link_geometry = separating_plane.negative_side_geometry;
+    other_side_geometry = separating_plane.positive_side_geometry;
   }
   const auto X_AB_multilinear =
       rational_forward_kinematics.CalcLinkPoseAsMultilinearPolynomial(
-          q_star, link_polytope->body_index(), separating_plane.expressed_link);
+          q_star, link_geometry->body_index(), separating_plane.expressed_link);
 
   const auto rationals = GenerateLinkOnOneSideOfPlaneRationalFunction(
-      rational_forward_kinematics, link_polytope, other_side_polytope,
+      rational_forward_kinematics, link_geometry, other_side_geometry,
       X_AB_multilinear, separating_plane.a, separating_plane.b, plane_side,
-      separating_plane.order);
-  EXPECT_EQ(rationals.size(), link_polytope->p_BV().cols());
+      separating_plane.order, separating_polytope_delta);
   for (const auto& rational : rationals) {
-    EXPECT_EQ(rational.link_polytope->get_id(), link_polytope->get_id());
-    EXPECT_EQ(rational.other_side_link_polytope->get_id(),
-              other_side_polytope->get_id());
+    EXPECT_EQ(rational.link_geometry->id(), link_geometry->id());
+    EXPECT_EQ(rational.other_side_link_geometry->id(),
+              other_side_geometry->id());
   }
-  // Now take many samples of q, evaluate a.dot(x) + b - 1 or -1 - a.dot(x) - b
-  // for these sampled q.
+
+  // Now take many samples of q, evaluate a.dot(x) + b - δ or -δ - a.dot(x)
+  // - b for these sampled q.
   std::vector<Eigen::VectorXd> q_samples;
   q_samples.push_back(
       q_star +
@@ -250,11 +338,6 @@ void TestGenerateLinkOnOneSideOfPlaneRationalFunction(
   auto context = plant.CreateDefaultContext();
   for (const auto& q : q_samples) {
     plant.SetPositions(context.get(), q);
-    Eigen::Matrix3Xd p_AV(3, link_polytope->p_BV().cols());
-    plant.CalcPointsPositions(
-        *context, plant.get_body(link_polytope->body_index()).body_frame(),
-        link_polytope->p_BV(),
-        plant.get_body(separating_plane.expressed_link).body_frame(), &p_AV);
     const Eigen::VectorXd t_val = ((q - q_star) / 2).array().tan();
     for (int i = 0; i < t_val.rows(); ++i) {
       auto it = env.find(rational_forward_kinematics.t()(i));
@@ -264,31 +347,119 @@ void TestGenerateLinkOnOneSideOfPlaneRationalFunction(
         it->second = t_val(i);
       }
     }
+    double separating_delta = 0;
+    if (link_geometry->type() == CollisionGeometryType::kPolytope &&
+        other_side_geometry->type() == CollisionGeometryType::kPolytope) {
+      separating_delta = separating_polytope_delta;
+    }
+    switch (link_geometry->type()) {
+      case CollisionGeometryType::kPolytope: {
+        const Eigen::Matrix3Xd p_BV =
+            link_geometry->X_BG() * GetVertices(link_geometry->geometry());
+        EXPECT_EQ(rationals.size(), p_BV.cols());
+        Eigen::Matrix3Xd p_AV(3, p_BV.cols());
+        plant.CalcPointsPositions(
+            *context, plant.get_body(link_geometry->body_index()).body_frame(),
+            p_BV, plant.get_body(separating_plane.expressed_link).body_frame(),
+            &p_AV);
 
-    for (int i = 0; i < static_cast<int>(rationals.size()); ++i) {
-      const double rational_val = rationals[i].rational.Evaluate(env);
-      // Now evaluate this rational function.
-      Eigen::Vector3d a_val;
-      for (int j = 0; j < 3; ++j) {
-        a_val(j) = separating_plane.a(j).Evaluate(env);
+        for (int i = 0; i < static_cast<int>(rationals.size()); ++i) {
+          EXPECT_TRUE(rationals[i].lorentz_cone_constraints.empty());
+          const double rational_val = rationals[i].rational.Evaluate(env);
+          // Now evaluate this rational function.
+          Eigen::Vector3d a_val;
+          for (int j = 0; j < 3; ++j) {
+            a_val(j) = separating_plane.a(j).Evaluate(env);
+          }
+          const double b_val = separating_plane.b.Evaluate(env);
+          const double rational_val_expected =
+              plane_side == PlaneSide::kPositive
+                  ? a_val.dot(p_AV.col(i)) + b_val - separating_delta
+                  : -separating_delta - a_val.dot(p_AV.col(i)) - b_val;
+          EXPECT_NEAR(rational_val, rational_val_expected, 1E-12);
+        }
+        break;
       }
-      const double b_val = separating_plane.b.Evaluate(env);
-      const double rational_val_expected =
-          plane_side == PlaneSide::kPositive
-              ? a_val.dot(p_AV.col(i)) + b_val - 1
-              : -1 - a_val.dot(p_AV.col(i)) - b_val;
-      EXPECT_NEAR(rational_val, rational_val_expected, 1E-12);
+      case CollisionGeometryType::kSphere: {
+        const auto* link_sphere =
+            dynamic_cast<const geometry::Sphere*>(&link_geometry->geometry());
+        Eigen::Vector3d p_AC;
+        plant.CalcPointsPositions(
+            *context, plant.get_body(link_geometry->body_index()).body_frame(),
+            link_geometry->X_BG().translation(),
+            plant.get_body(separating_plane.expressed_link).body_frame(),
+            &p_AC);
+        EXPECT_EQ(rationals.size(), 1u);
+        const double rational_val = rationals[0].rational.Evaluate(env);
+        const double radius = link_sphere->radius();
+        // Now evaluate this rational function.
+        Eigen::Vector3d a_val;
+        for (int j = 0; j < 3; ++j) {
+          a_val(j) = separating_plane.a(j).Evaluate(env);
+        }
+        const double b_val = separating_plane.b.Evaluate(env);
+        const double rational_val_expected =
+            plane_side == PlaneSide::kPositive
+                ? a_val.dot(p_AC) + b_val - separating_delta - radius
+                : -separating_delta - radius - a_val.dot(p_AC) - b_val;
+        EXPECT_NEAR(rational_val, rational_val_expected, 1E-12);
+        EXPECT_EQ(rationals[0].lorentz_cone_constraints.size(), 1u);
+        CheckRationalLorentzConeConstraint(
+            rationals[0].lorentz_cone_constraints[0], separating_plane.a,
+            1E-12);
+        break;
+      }
+      case CollisionGeometryType::kCapsule: {
+        const auto* link_capsule =
+            dynamic_cast<const geometry::Capsule*>(&link_geometry->geometry());
+        Eigen::Matrix<double, 3, 2> p_AC;
+        Eigen::Matrix<double, 3, 2> p_BC;
+        p_BC.col(0) = link_geometry->X_BG() *
+                      Eigen::Vector3d(0, 0, -link_capsule->length() / 2);
+        p_BC.col(1) = link_geometry->X_BG() *
+                      Eigen::Vector3d(0, 0, link_capsule->length() / 2);
+        plant.CalcPointsPositions(
+            *context, plant.get_body(link_geometry->body_index()).body_frame(),
+            p_BC, plant.get_body(separating_plane.expressed_link).body_frame(),
+            &p_AC);
+        Eigen::Vector3d a_val;
+        for (int j = 0; j < 3; ++j) {
+          a_val(j) = separating_plane.a(j).Evaluate(env);
+        }
+        const double b_val = separating_plane.b.Evaluate(env);
+        EXPECT_EQ(rationals.size(), 2u);
+        for (int i = 0; i < 2; ++i) {
+          const double rational_val = rationals[i].rational.Evaluate(env);
+          const double radius = link_capsule->radius();
+          // Now evaluate this rational function.
+          const double rational_val_expected =
+              plane_side == PlaneSide::kPositive
+                  ? a_val.dot(p_AC.col(i)) + b_val - separating_delta - radius
+                  : -separating_delta - radius - a_val.dot(p_AC.col(i)) - b_val;
+          EXPECT_NEAR(rational_val, rational_val_expected, 1E-12);
+        }
+        EXPECT_EQ(rationals[0].lorentz_cone_constraints.size(), 1u);
+        CheckRationalLorentzConeConstraint(
+            rationals[0].lorentz_cone_constraints[0], separating_plane.a,
+            1E-12);
+        EXPECT_TRUE(rationals[1].lorentz_cone_constraints.empty());
+        break;
+      }
+      default: {
+        throw std::runtime_error("Not implemented yet");
+      }
     }
   }
 }
 
-TEST_F(IiwaCspaceTest, GenerateLinkOnOneSideOfPlaneRationalFunction1) {
+TEST_F(IiwaCspaceTest, GenerateLinkOnOneSideOfPlaneRationalFunction) {
   scene_graph_->collision_filter_manager().ApplyTransient(
       geometry::CollisionFilterDeclaration().AllowWithin(
           geometry::GeometrySet({link7_polytopes_id_[0], obstacles_id_[0]})));
-  const CspaceFreeRegion dut(*diagram_, plant_, scene_graph_,
-                             SeparatingPlaneOrder::kAffine,
-                             CspaceRegionType::kGenericPolytope);
+  const double separating_polytope_delta = 0.1;
+  const CspaceFreeRegion dut(
+      *diagram_, plant_, scene_graph_, SeparatingPlaneOrder::kAffine,
+      CspaceRegionType::kGenericPolytope, separating_polytope_delta);
   const Eigen::VectorXd q_star1 = Eigen::VectorXd::Zero(7);
   const Eigen::VectorXd q_star2 =
       (Eigen::VectorXd(7) << 0.1, 0.2, -0.1, 0.3, 0.2, 0.4, 0.2).finished();
@@ -297,34 +468,79 @@ TEST_F(IiwaCspaceTest, GenerateLinkOnOneSideOfPlaneRationalFunction1) {
   for (const auto plane_side : {PlaneSide::kPositive, PlaneSide::kNegative}) {
     TestGenerateLinkOnOneSideOfPlaneRationalFunction(
         dut.rational_forward_kinematics(), separating_plane, plane_side,
-        q_star1);
+        q_star1, separating_polytope_delta);
     TestGenerateLinkOnOneSideOfPlaneRationalFunction(
         dut.rational_forward_kinematics(), separating_plane, plane_side,
-        q_star2);
+        q_star2, separating_polytope_delta);
+  }
+}
+
+TEST_F(IiwaNonpolytopeCollisionCspaceTest,
+       GenerateLinkOnOneSideOfPlaneRationalFunction) {
+  const double separating_polytope_delta = 0.1;
+  const CspaceFreeRegion dut(
+      *diagram_, plant_, scene_graph_, SeparatingPlaneOrder::kConstant,
+      CspaceRegionType::kGenericPolytope, separating_polytope_delta);
+  const Eigen::VectorXd q_star1 = Eigen::VectorXd::Zero(7);
+
+  for (const auto& separating_plane : dut.separating_planes()) {
+    for (const auto plane_side : {PlaneSide::kPositive, PlaneSide::kNegative}) {
+      TestGenerateLinkOnOneSideOfPlaneRationalFunction(
+          dut.rational_forward_kinematics(), separating_plane, plane_side,
+          q_star1, separating_polytope_delta);
+    }
   }
 }
 
 void TestGenerateLinkOnOneSideOfPlaneRationals(
     const CspaceFreeRegion& dut,
     const Eigen::Ref<const Eigen::VectorXd>& q_star,
-    const CspaceFreeRegion::FilteredCollisionPairs& filtered_collision_pairs) {
+    const CspaceFreeRegion::FilteredCollisionPairs& filtered_collision_pairs,
+    SeparatingPlaneOrder plane_order_for_polytope) {
   const auto rationals = dut.GenerateLinkOnOneSideOfPlaneRationals(
       q_star, filtered_collision_pairs);
   // Check the size of rationals.
   int rationals_size = 0;
   for (const auto& [link_pair, separating_plane_index] :
-       dut.map_polytopes_to_separating_planes()) {
+       dut.map_collisions_to_separating_planes()) {
     if (!IsGeometryPairCollisionIgnored(link_pair.first(), link_pair.second(),
                                         filtered_collision_pairs)) {
-      rationals_size += dut.separating_planes()[separating_plane_index]
-                            .positive_side_polytope->p_BV()
-                            .cols() +
-                        dut.separating_planes()[separating_plane_index]
-                            .negative_side_polytope->p_BV()
-                            .cols();
+      const auto& separating_plane =
+          dut.separating_planes()[separating_plane_index];
+      for (const auto link_geometry :
+           {separating_plane.positive_side_geometry,
+            separating_plane.negative_side_geometry}) {
+        switch (link_geometry->type()) {
+          case CollisionGeometryType::kPolytope: {
+            rationals_size += GetVertices(link_geometry->geometry()).cols();
+            break;
+          }
+          case CollisionGeometryType::kSphere: {
+            rationals_size += 1;
+            break;
+          }
+          case CollisionGeometryType::kCapsule: {
+            rationals_size += 2;
+            break;
+          }
+          default: {
+            throw std::runtime_error("Not implemented");
+          }
+        }
+      }
     }
   }
   EXPECT_EQ(rationals.size(), rationals_size);
+  // Check if each rationals has the plane order matching the geometry type.
+  for (const auto& rational : rationals) {
+    if (rational.link_geometry->type() == CollisionGeometryType::kPolytope &&
+        rational.other_side_link_geometry->type() ==
+            CollisionGeometryType::kPolytope) {
+      EXPECT_EQ(rational.plane_order, plane_order_for_polytope);
+    } else {
+      EXPECT_EQ(rational.plane_order, SeparatingPlaneOrder::kConstant);
+    }
+  }
 }
 
 TEST_F(IiwaCspaceTest, GenerateLinkOnOneSideOfPlaneRationals) {
@@ -334,23 +550,39 @@ TEST_F(IiwaCspaceTest, GenerateLinkOnOneSideOfPlaneRationals) {
               geometry::GeometrySet({link7_polytopes_id_[1],
                                      link5_polytopes_id_[0], obstacles_id_[0],
                                      obstacles_id_[1]})));
-  const CspaceFreeRegion dut1(*diagram_, plant_, scene_graph_,
-                              SeparatingPlaneOrder::kAffine,
-                              CspaceRegionType::kGenericPolytope);
+  const double separating_polytope_delta{0.1};
+  SeparatingPlaneOrder plane_order_for_polytope = SeparatingPlaneOrder::kAffine;
+  const CspaceFreeRegion dut1(
+      *diagram_, plant_, scene_graph_, plane_order_for_polytope,
+      CspaceRegionType::kGenericPolytope, separating_polytope_delta);
   const Eigen::VectorXd q_star = Eigen::VectorXd::Zero(7);
-  TestGenerateLinkOnOneSideOfPlaneRationals(dut1, q_star, {});
+  TestGenerateLinkOnOneSideOfPlaneRationals(dut1, q_star, {},
+                                            plane_order_for_polytope);
 
   // Multiple pairs of polytopes.
   scene_graph_->collision_filter_manager().RemoveDeclaration(filter_id);
-  const CspaceFreeRegion dut2(*diagram_, plant_, scene_graph_,
-                              SeparatingPlaneOrder::kAffine,
-                              CspaceRegionType::kGenericPolytope);
-  TestGenerateLinkOnOneSideOfPlaneRationals(dut2, q_star, {});
+  const CspaceFreeRegion dut2(
+      *diagram_, plant_, scene_graph_, plane_order_for_polytope,
+      CspaceRegionType::kGenericPolytope, separating_polytope_delta);
+  TestGenerateLinkOnOneSideOfPlaneRationals(dut2, q_star, {},
+                                            plane_order_for_polytope);
   // Now test with filtered collision pairs.
   const CspaceFreeRegion::FilteredCollisionPairs filtered_collision_pairs{
       {{link7_polytopes_id_[0], obstacles_id_[0]}}};
-  TestGenerateLinkOnOneSideOfPlaneRationals(dut2, q_star,
-                                            filtered_collision_pairs);
+  TestGenerateLinkOnOneSideOfPlaneRationals(
+      dut2, q_star, filtered_collision_pairs, plane_order_for_polytope);
+}
+
+TEST_F(IiwaNonpolytopeCollisionCspaceTest,
+       GenerateLinkOnOneSideOfPlaneRationals) {
+  const double separating_polytope_delta{0.1};
+  SeparatingPlaneOrder plane_order_for_polytope = SeparatingPlaneOrder::kAffine;
+  const CspaceFreeRegion dut1(
+      *diagram_, plant_, scene_graph_, plane_order_for_polytope,
+      CspaceRegionType::kGenericPolytope, separating_polytope_delta);
+  const Eigen::VectorXd q_star = Eigen::VectorXd::Zero(7);
+  TestGenerateLinkOnOneSideOfPlaneRationals(dut1, q_star, {},
+                                            plane_order_for_polytope);
 }
 
 // Check p has degree at most 2 for each variable in t.
@@ -362,17 +594,20 @@ void CheckPolynomialDegree2(const symbolic::Polynomial& p,
 }
 
 void ConstructInitialCspacePolytope(const CspaceFreeRegion& dut,
+                                    const systems::Diagram<double>& diagram,
                                     Eigen::VectorXd* q_star, Eigen::MatrixXd* C,
                                     Eigen::VectorXd* d,
                                     Eigen::VectorXd* q_not_in_collision) {
   const auto& plant = dut.rational_forward_kinematics().plant();
-  auto context = plant.CreateDefaultContext();
+  auto diagram_context = diagram.CreateDefaultContext();
+  auto context =
+      &diagram.GetMutableSubsystemContext(plant, diagram_context.get());
   *q_star = Eigen::VectorXd::Zero(7);
 
   // I will build a small C-space polytope C*t<=d around q_not_in_collision;
   *q_not_in_collision =
       (Eigen::VectorXd(7) << 0.5, 0.3, -0.3, 0.1, 0.4, 0.2, 0.1).finished();
-  plant.SetPositions(context.get(), *q_not_in_collision);
+  plant.SetPositions(context, *q_not_in_collision);
   ASSERT_FALSE(dut.IsPostureInCollision(*context));
 
   // First generate a region C * t <= d.
@@ -440,10 +675,12 @@ TEST_F(IiwaCspaceTest, ConstructProgramForCspacePolytope) {
       geometry::CollisionFilterDeclaration().ExcludeWithin(
           geometry::GeometrySet({link7_polytopes_id_[1], link5_polytopes_id_[0],
                                  obstacles_id_[0], obstacles_id_[1]})));
+  const double separating_polytope_delta{0.1};
   const CspaceFreeRegion dut(*diagram_, plant_, scene_graph_,
 
                              SeparatingPlaneOrder::kAffine,
-                             CspaceRegionType::kGenericPolytope);
+                             CspaceRegionType::kGenericPolytope,
+                             separating_polytope_delta);
   const auto& plant = dut.rational_forward_kinematics().plant();
   auto context = plant.CreateDefaultContext();
 
@@ -451,7 +688,8 @@ TEST_F(IiwaCspaceTest, ConstructProgramForCspacePolytope) {
   Eigen::MatrixXd C;
   Eigen::VectorXd d;
   Eigen::VectorXd q_not_in_collision;
-  ConstructInitialCspacePolytope(dut, &q_star, &C, &d, &q_not_in_collision);
+  ConstructInitialCspacePolytope(dut, *diagram_, &q_star, &C, &d,
+                                 &q_not_in_collision);
 
   CspaceFreeRegion::FilteredCollisionPairs filtered_collision_pairs{};
   auto clock_start = std::chrono::system_clock::now();
@@ -542,12 +780,9 @@ TEST_F(IiwaCspaceTest, ConstructProgramForCspacePolytope) {
   EXPECT_TRUE(result.is_success());
 }
 
-TEST_F(IiwaCspaceTest, GenerateTuplesForBilinearAlternation) {
-  const CspaceFreeRegion dut(*diagram_, plant_, scene_graph_,
-                             SeparatingPlaneOrder::kAffine,
-                             CspaceRegionType::kGenericPolytope);
-  const Eigen::VectorXd q_star = Eigen::VectorXd::Zero(7);
-  const int C_rows = 5;
+void CheckGenerateTuplesForBilinearAlternation(const CspaceFreeRegion& dut,
+                                               const Eigen::VectorXd& q_star,
+                                               int C_rows) {
   std::vector<CspaceFreeRegion::CspacePolytopeTuple> alternation_tuples;
   VectorX<symbolic::Polynomial> d_minus_Ct;
   Eigen::VectorXd t_lower, t_upper;
@@ -556,16 +791,52 @@ TEST_F(IiwaCspaceTest, GenerateTuplesForBilinearAlternation) {
   VectorX<symbolic::Variable> d_var, lagrangian_gram_vars, verified_gram_vars,
       separating_plane_vars;
   std::vector<std::vector<int>> separating_plane_to_tuples;
+  std::vector<std::vector<solvers::Binding<solvers::LorentzConeConstraint>>>
+      separating_plane_to_lorentz_cone_constraints;
   dut.GenerateTuplesForBilinearAlternation(
       q_star, {}, C_rows, &alternation_tuples, &d_minus_Ct, &t_lower, &t_upper,
       &t_minus_t_lower, &t_upper_minus_t, &C_var, &d_var, &lagrangian_gram_vars,
-      &verified_gram_vars, &separating_plane_vars, &separating_plane_to_tuples);
+      &verified_gram_vars, &separating_plane_vars, &separating_plane_to_tuples,
+      &separating_plane_to_lorentz_cone_constraints);
   int rational_count = 0;
+  std::vector<int> separating_plane_to_lorentz_cone_constraints_count(
+      dut.separating_planes().size(), 0);
   for (const auto& separating_plane : dut.separating_planes()) {
-    rational_count += separating_plane.positive_side_polytope->p_BV().cols() +
-                      separating_plane.negative_side_polytope->p_BV().cols();
+    const int plane_index = dut.map_collisions_to_separating_planes().at(
+        SortedPair<geometry::GeometryId>(
+            separating_plane.positive_side_geometry->id(),
+            separating_plane.negative_side_geometry->id()));
+    for (const CollisionGeometry* link_geometry :
+         {separating_plane.positive_side_geometry,
+          separating_plane.negative_side_geometry}) {
+      switch (link_geometry->type()) {
+        case CollisionGeometryType::kPolytope: {
+          rational_count += GetVertices(link_geometry->geometry()).cols();
+          break;
+        }
+        case CollisionGeometryType::kSphere: {
+          rational_count += 1;
+          separating_plane_to_lorentz_cone_constraints_count[plane_index] += 1;
+          break;
+        }
+        case CollisionGeometryType::kCapsule: {
+          rational_count += 2;
+          separating_plane_to_lorentz_cone_constraints_count[plane_index] += 1;
+          break;
+        }
+        default: {
+          throw std::runtime_error("Not implemented yet.");
+        }
+      }
+    }
   }
   EXPECT_EQ(alternation_tuples.size(), rational_count);
+  EXPECT_EQ(separating_plane_to_lorentz_cone_constraints.size(),
+            dut.separating_planes().size());
+  for (int i = 0; i < static_cast<int>(dut.separating_planes().size()); ++i) {
+    EXPECT_EQ(separating_plane_to_lorentz_cone_constraints[i].size(),
+              separating_plane_to_lorentz_cone_constraints_count[i]);
+  }
   // Now count the total number of lagrangian gram vars.
   int lagrangian_gram_vars_count = 0;
   int verified_gram_vars_count = 0;
@@ -631,6 +902,27 @@ TEST_F(IiwaCspaceTest, GenerateTuplesForBilinearAlternation) {
     }
   }
   EXPECT_EQ(tuple_indices_set.size(), rational_count);
+}
+
+TEST_F(IiwaCspaceTest, GenerateTuplesForBilinearAlternation) {
+  const double separating_polytope_delta{0.1};
+  const CspaceFreeRegion dut(
+      *diagram_, plant_, scene_graph_, SeparatingPlaneOrder::kAffine,
+      CspaceRegionType::kGenericPolytope, separating_polytope_delta);
+  const Eigen::VectorXd q_star = Eigen::VectorXd::Zero(7);
+  const int C_rows = 5;
+  CheckGenerateTuplesForBilinearAlternation(dut, q_star, C_rows);
+}
+
+TEST_F(IiwaNonpolytopeCollisionCspaceTest,
+       GenerateTuplesForBilinearAlternation) {
+  const double separating_polytope_delta{0.001};
+  const CspaceFreeRegion dut(
+      *diagram_, plant_, scene_graph_, SeparatingPlaneOrder::kAffine,
+      CspaceRegionType::kGenericPolytope, separating_polytope_delta);
+  const Eigen::VectorXd q_star = Eigen::VectorXd::Zero(7);
+  const int C_rows = 4;
+  CheckGenerateTuplesForBilinearAlternation(dut, q_star, C_rows);
 }
 
 void CheckPsd(const Eigen::Ref<const Eigen::MatrixXd>& mat, double tol) {
@@ -717,9 +1009,10 @@ TEST_F(IiwaCspaceTest, ConstructLagrangianAndPolytopeProgram) {
   // Test both ConstructLagrangianProgram and ConstructPolytopeProgram (the
   // latter needs the result from the former).
   ApplyFilter();
-  const CspaceFreeRegion dut(*diagram_, plant_, scene_graph_,
-                             SeparatingPlaneOrder::kAffine,
-                             CspaceRegionType::kGenericPolytope);
+  const double separating_polytope_delta{0.1};
+  const CspaceFreeRegion dut(
+      *diagram_, plant_, scene_graph_, SeparatingPlaneOrder::kAffine,
+      CspaceRegionType::kGenericPolytope, separating_polytope_delta);
   const auto& plant = dut.rational_forward_kinematics().plant();
   auto context = plant.CreateDefaultContext();
 
@@ -727,7 +1020,8 @@ TEST_F(IiwaCspaceTest, ConstructLagrangianAndPolytopeProgram) {
   Eigen::MatrixXd C;
   Eigen::VectorXd d;
   Eigen::VectorXd q_not_in_collision;
-  ConstructInitialCspacePolytope(dut, &q_star, &C, &d, &q_not_in_collision);
+  ConstructInitialCspacePolytope(dut, *diagram_, &q_star, &C, &d,
+                                 &q_not_in_collision);
 
   CspaceFreeRegion::FilteredCollisionPairs filtered_collision_pairs{};
   std::vector<CspaceFreeRegion::CspacePolytopeTuple> alternation_tuples;
@@ -738,19 +1032,30 @@ TEST_F(IiwaCspaceTest, ConstructLagrangianAndPolytopeProgram) {
   VectorX<symbolic::Variable> d_var, lagrangian_gram_vars, verified_gram_vars,
       separating_plane_vars;
   std::vector<std::vector<int>> separating_plane_to_tuples;
+  std::vector<std::vector<solvers::Binding<solvers::LorentzConeConstraint>>>
+      separating_plane_to_lorentz_cone_constraints;
   dut.GenerateTuplesForBilinearAlternation(
       q_star, filtered_collision_pairs, C.rows(), &alternation_tuples,
       &d_minus_Ct, &t_lower, &t_upper, &t_minus_t_lower, &t_upper_minus_t,
       &C_var, &d_var, &lagrangian_gram_vars, &verified_gram_vars,
-      &separating_plane_vars, &separating_plane_to_tuples);
+      &separating_plane_vars, &separating_plane_to_tuples,
+      &separating_plane_to_lorentz_cone_constraints);
 
   MatrixX<symbolic::Variable> P;
   VectorX<symbolic::Variable> q;
   auto clock_start = std::chrono::system_clock::now();
   double redundant_tighten = 0;
+  std::vector<solvers::Binding<solvers::LorentzConeConstraint>>
+      separating_plane_lorentz_cone_constraints;
+  for (const auto& bindings : separating_plane_to_lorentz_cone_constraints) {
+    separating_plane_lorentz_cone_constraints.insert(
+        separating_plane_lorentz_cone_constraints.end(), bindings.begin(),
+        bindings.end());
+  }
   auto prog = dut.ConstructLagrangianProgram(
       alternation_tuples, C, d, lagrangian_gram_vars, verified_gram_vars,
-      separating_plane_vars, t_lower, t_upper, {}, redundant_tighten, &P, &q);
+      separating_plane_vars, separating_plane_lorentz_cone_constraints, t_lower,
+      t_upper, {}, redundant_tighten, &P, &q);
   auto clock_finish = std::chrono::system_clock::now();
   std::cout << "ConstructLagrangianProgram takes "
             << static_cast<float>(
@@ -787,7 +1092,8 @@ TEST_F(IiwaCspaceTest, ConstructLagrangianAndPolytopeProgram) {
   clock_start = std::chrono::system_clock::now();
   auto prog_polytope = dut.ConstructPolytopeProgram(
       alternation_tuples, C_var, d_var, d_minus_Ct, lagrangian_gram_var_vals,
-      verified_gram_vars, separating_plane_vars, t_minus_t_lower,
+      verified_gram_vars, separating_plane_vars,
+      separating_plane_to_lorentz_cone_constraints, t_minus_t_lower,
       t_upper_minus_t, {});
   margin = prog_polytope->NewContinuousVariables(C_var.rows(), "margin");
   AddOuterPolytope(prog_polytope.get(), P_sol, q_sol, C_var, d_var, margin);
@@ -875,11 +1181,16 @@ TEST_F(IiwaCspaceTest, ConstructLagrangianAndPolytopeProgram) {
   }
 }
 
-TEST_F(IiwaCspaceTest, CspacePolytopeBilinearAlternation) {
-  ApplyFilter();
-  const CspaceFreeRegion dut(*diagram_, plant_, scene_graph_,
-                             SeparatingPlaneOrder::kAffine,
-                             CspaceRegionType::kGenericPolytope);
+TEST_F(IiwaNonpolytopeCollisionCspaceTest,
+       ConstructLagrangianAndPolytopeProgram) {
+  // Test ConstructLagrangianProgram and ConstructPolytopeProgram. Similar to
+  // the test IiwaCspaceTest.ConstructLagrangianAndPolytopeProgram, but with
+  // non-polytope collision geometries, hence we need to check whether the
+  // additional Lorentz cone constraints are satisfied for the separating plane.
+  const double separating_polytope_delta{0.001};
+  const CspaceFreeRegion dut(
+      *diagram_, plant_, scene_graph_, SeparatingPlaneOrder::kAffine,
+      CspaceRegionType::kGenericPolytope, separating_polytope_delta);
   const auto& plant = dut.rational_forward_kinematics().plant();
   auto context = plant.CreateDefaultContext();
 
@@ -887,7 +1198,143 @@ TEST_F(IiwaCspaceTest, CspacePolytopeBilinearAlternation) {
   Eigen::MatrixXd C;
   Eigen::VectorXd d;
   Eigen::VectorXd q_not_in_collision;
-  ConstructInitialCspacePolytope(dut, &q_star, &C, &d, &q_not_in_collision);
+  ConstructInitialCspacePolytope(dut, *diagram_, &q_star, &C, &d,
+                                 &q_not_in_collision);
+
+  CspaceFreeRegion::FilteredCollisionPairs filtered_collision_pairs{};
+  std::vector<CspaceFreeRegion::CspacePolytopeTuple> alternation_tuples;
+  VectorX<symbolic::Polynomial> d_minus_Ct;
+  Eigen::VectorXd t_lower, t_upper;
+  VectorX<symbolic::Polynomial> t_minus_t_lower, t_upper_minus_t;
+  MatrixX<symbolic::Variable> C_var;
+  VectorX<symbolic::Variable> d_var, lagrangian_gram_vars, verified_gram_vars,
+      separating_plane_vars;
+  std::vector<std::vector<int>> separating_plane_to_tuples;
+  std::vector<std::vector<solvers::Binding<solvers::LorentzConeConstraint>>>
+      separating_plane_to_lorentz_cone_constraints;
+  dut.GenerateTuplesForBilinearAlternation(
+      q_star, filtered_collision_pairs, C.rows(), &alternation_tuples,
+      &d_minus_Ct, &t_lower, &t_upper, &t_minus_t_lower, &t_upper_minus_t,
+      &C_var, &d_var, &lagrangian_gram_vars, &verified_gram_vars,
+      &separating_plane_vars, &separating_plane_to_tuples,
+      &separating_plane_to_lorentz_cone_constraints);
+
+  MatrixX<symbolic::Variable> P;
+  VectorX<symbolic::Variable> q;
+  auto clock_start = std::chrono::system_clock::now();
+  double redundant_tighten = 0;
+  std::vector<solvers::Binding<solvers::LorentzConeConstraint>>
+      separating_plane_lorentz_cone_constraints;
+  for (const auto& binding : separating_plane_to_lorentz_cone_constraints) {
+    separating_plane_lorentz_cone_constraints.insert(
+        separating_plane_lorentz_cone_constraints.end(), binding.begin(),
+        binding.end());
+  }
+  auto prog = dut.ConstructLagrangianProgram(
+      alternation_tuples, C, d, lagrangian_gram_vars, verified_gram_vars,
+      separating_plane_vars, separating_plane_lorentz_cone_constraints, t_lower,
+      t_upper, {}, redundant_tighten, &P, &q);
+  auto clock_finish = std::chrono::system_clock::now();
+  std::cout << "ConstructLagrangianProgram takes "
+            << static_cast<float>(
+                   std::chrono::duration_cast<std::chrono::milliseconds>(
+                       clock_finish - clock_start)
+                       .count()) /
+                   1000
+            << "s\n";
+  prog->AddMaximizeLogDeterminantCost(P.cast<symbolic::Expression>());
+  solvers::SolverOptions solver_options;
+  solver_options.SetOption(solvers::CommonSolverOption::kPrintToConsole, 1);
+  const auto result_lagrangian =
+      solvers::Solve(*prog, std::nullopt, solver_options);
+  EXPECT_TRUE(result_lagrangian.is_success());
+  // Now test if the additional Lorentz cone constraints on the separating
+  // planes are satisfied.
+  auto check_separating_plane_lorentz_cone =
+      [&dut](const solvers::MathematicalProgramResult& result) {
+        for (const auto& plane : dut.separating_planes()) {
+          if (plane.positive_side_geometry->type() !=
+                  CollisionGeometryType::kPolytope ||
+              plane.negative_side_geometry->type() !=
+                  CollisionGeometryType::kPolytope) {
+            symbolic::Environment env;
+            env.insert(plane.decision_variables,
+                       result.GetSolution(plane.decision_variables));
+            Eigen::Vector3d a_val;
+            for (int i = 0; i < 3; ++i) {
+              a_val(i) = plane.a(i).Evaluate(env);
+            }
+            for (const auto collision_geometry :
+                 {plane.positive_side_geometry, plane.negative_side_geometry}) {
+              switch (collision_geometry->type()) {
+                case CollisionGeometryType::kSphere: {
+                  EXPECT_LE(a_val.norm(), 1 + 1E-8);
+                  break;
+                }
+                case CollisionGeometryType::kCapsule: {
+                  EXPECT_LE(a_val.norm(), 1 + 1E-8);
+                  break;
+                }
+                default: {
+                }
+              }
+            }
+          }
+        }
+      };
+
+  check_separating_plane_lorentz_cone(result_lagrangian);
+
+  const auto P_sol = result_lagrangian.GetSolution(P);
+  const auto q_sol = result_lagrangian.GetSolution(q);
+
+  const Eigen::VectorXd lagrangian_gram_var_vals =
+      result_lagrangian.GetSolution(lagrangian_gram_vars);
+
+  // Now test ConstructPolytopeProgram using the lagrangian result.
+  VectorX<symbolic::Variable> margin;
+  clock_start = std::chrono::system_clock::now();
+  auto prog_polytope = dut.ConstructPolytopeProgram(
+      alternation_tuples, C_var, d_var, d_minus_Ct, lagrangian_gram_var_vals,
+      verified_gram_vars, separating_plane_vars,
+      separating_plane_to_lorentz_cone_constraints, t_minus_t_lower,
+      t_upper_minus_t, {});
+  margin = prog_polytope->NewContinuousVariables(C_var.rows(), "margin");
+  AddOuterPolytope(prog_polytope.get(), P_sol, q_sol, C_var, d_var, margin);
+  prog_polytope->AddBoundingBoxConstraint(0, kInf, margin);
+  clock_finish = std::chrono::system_clock::now();
+  std::cout << "ConstructPolytopeProgram takes "
+            << static_cast<float>(
+                   std::chrono::duration_cast<std::chrono::milliseconds>(
+                       clock_finish - clock_start)
+                       .count()) /
+                   1000
+            << "s\n";
+  // Number of PSD constraint is the number of SOS constraint, equal to the
+  // number of rational numerators.
+  // Maximize the geometric mean of the margin.
+  prog_polytope->AddMaximizeGeometricMeanCost(
+      Eigen::MatrixXd::Identity(margin.rows(), margin.rows()),
+      1E-4 * Eigen::VectorXd::Ones(margin.rows()), margin);
+  const auto result_polytope =
+      solvers::Solve(*prog_polytope, std::nullopt, solver_options);
+  EXPECT_TRUE(result_polytope.is_success());
+
+  check_separating_plane_lorentz_cone(result_polytope);
+}
+
+void TestBilinearAlternation(const CspaceFreeRegion& dut,
+                             const systems::Diagram<double>& diagram,
+                             bool multi_thread) {
+  const auto& plant = dut.rational_forward_kinematics().plant();
+  auto context = plant.CreateDefaultContext();
+
+  Eigen::VectorXd q_star;
+  Eigen::MatrixXd C;
+  Eigen::VectorXd d;
+  Eigen::VectorXd q_not_in_collision;
+  ConstructInitialCspacePolytope(dut, diagram, &q_star, &C, &d,
+                                 &q_not_in_collision);
 
   CspaceFreeRegion::FilteredCollisionPairs filtered_collision_pairs{};
   // Intentially multiplies a factor to make the rows of C unnormalized.
@@ -905,7 +1352,8 @@ TEST_F(IiwaCspaceTest, CspacePolytopeBilinearAlternation) {
                                    .convergence_tol = 0.001,
                                    .lagrangian_backoff_scale = 0.05,
                                    .polytope_backoff_scale = 0.05,
-                                   .verbose = true};
+                                   .verbose = true,
+                                   .multi_thread = multi_thread};
   solvers::SolverOptions solver_options;
   solver_options.SetOption(solvers::CommonSolverOption::kPrintToConsole, true);
   //  std::vector<SeparatingPlane> separating_planes_sol;
@@ -931,11 +1379,31 @@ TEST_F(IiwaCspaceTest, CspacePolytopeBilinearAlternation) {
   EXPECT_TRUE(((C_final * t_inner_pts).array() <= d_final.array()).all());
 }
 
+TEST_F(IiwaCspaceTest, CspacePolytopeBilinearAlternation) {
+  ApplyFilter();
+  const double separating_polytope_delta{0.1};
+  const CspaceFreeRegion dut(
+      *diagram_, plant_, scene_graph_, SeparatingPlaneOrder::kAffine,
+      CspaceRegionType::kGenericPolytope, separating_polytope_delta);
+  bool multi_thread{false};
+  TestBilinearAlternation(dut, *diagram_, multi_thread);
+}
+
+TEST_F(IiwaNonpolytopeCollisionCspaceTest, CspacePolytopeBilinearAlternation) {
+  const double separating_polytope_delta{0.1};
+  const CspaceFreeRegion dut(
+      *diagram_, plant_, scene_graph_, SeparatingPlaneOrder::kAffine,
+      CspaceRegionType::kGenericPolytope, separating_polytope_delta);
+  bool multi_thread{true};
+  TestBilinearAlternation(dut, *diagram_, multi_thread);
+}
+
 TEST_F(IiwaCspaceTest, CspacePolytopeBinarySearch) {
   ApplyFilter();
-  const CspaceFreeRegion dut(*diagram_, plant_, scene_graph_,
-                             SeparatingPlaneOrder::kAffine,
-                             CspaceRegionType::kGenericPolytope);
+  const double separating_polytope_delta{0.1};
+  const CspaceFreeRegion dut(
+      *diagram_, plant_, scene_graph_, SeparatingPlaneOrder::kAffine,
+      CspaceRegionType::kGenericPolytope, separating_polytope_delta);
   const auto& plant = dut.rational_forward_kinematics().plant();
   auto context = plant.CreateDefaultContext();
 
@@ -943,7 +1411,8 @@ TEST_F(IiwaCspaceTest, CspacePolytopeBinarySearch) {
   Eigen::MatrixXd C;
   Eigen::VectorXd d;
   Eigen::VectorXd q_not_in_collision;
-  ConstructInitialCspacePolytope(dut, &q_star, &C, &d, &q_not_in_collision);
+  ConstructInitialCspacePolytope(dut, *diagram_, &q_star, &C, &d,
+                                 &q_not_in_collision);
 
   CspaceFreeRegion::FilteredCollisionPairs filtered_collision_pairs{};
   // Intentially multiplies a factor to make the rows of C unnormalized.
@@ -955,7 +1424,7 @@ TEST_F(IiwaCspaceTest, CspacePolytopeBinarySearch) {
   CspaceFreeRegion::BinarySearchOption binary_search_option{
       .epsilon_max = 1, .epsilon_min = 0.1, .max_iters = 4, .search_d = false};
   solvers::SolverOptions solver_options;
-  solver_options.SetOption(solvers::CommonSolverOption::kPrintToConsole, true);
+  solver_options.SetOption(solvers::CommonSolverOption::kPrintToConsole, false);
   Eigen::VectorXd d_final;
   CspaceFreeRegionSolution cspace_free_region_solution;
   dut.CspacePolytopeBinarySearch(q_star, filtered_collision_pairs, C, d,
@@ -989,49 +1458,77 @@ void CheckSeparatingPlanesSol(
        plane_index < static_cast<int>(dut.separating_planes().size());
        ++plane_index) {
     if (is_plane_active[plane_index]) {
-      EXPECT_EQ(separating_planes_sol[active_plane_count]
-                    .positive_side_polytope->get_id(),
-                dut.separating_planes()[plane_index]
-                    .positive_side_polytope->get_id());
-      EXPECT_EQ(separating_planes_sol[active_plane_count]
-                    .negative_side_polytope->get_id(),
-                dut.separating_planes()[plane_index]
-                    .negative_side_polytope->get_id());
+      const SeparatingPlane& separating_plane_sol =
+          separating_planes_sol[active_plane_count];
+      EXPECT_EQ(
+          separating_plane_sol.positive_side_geometry->id(),
+          dut.separating_planes()[plane_index].positive_side_geometry->id());
+      EXPECT_EQ(
+          separating_plane_sol.negative_side_geometry->id(),
+          dut.separating_planes()[plane_index].negative_side_geometry->id());
       for (int i = 0; i < 3; ++i) {
-        EXPECT_TRUE(separating_planes_sol[active_plane_count]
-                        .a(i)
-                        .GetVariables()
-                        .IsSubsetOf(t_vars));
+        EXPECT_TRUE(
+            separating_plane_sol.a(i).GetVariables().IsSubsetOf(t_vars));
       }
-      EXPECT_TRUE(
-          separating_planes_sol[active_plane_count].b.GetVariables().IsSubsetOf(
-              t_vars));
+      EXPECT_TRUE(separating_plane_sol.b.GetVariables().IsSubsetOf(t_vars));
+      for (const auto* collision :
+           {dut.separating_planes()[plane_index].positive_side_geometry,
+            dut.separating_planes()[plane_index].negative_side_geometry}) {
+        switch (collision->type()) {
+          case CollisionGeometryType::kPolytope: {
+            break;
+          }
+          case CollisionGeometryType::kSphere:
+          case CollisionGeometryType::kCapsule: {
+            switch (dut.separating_planes()[plane_index].order) {
+              case SeparatingPlaneOrder::kConstant: {
+                Eigen::Vector3d a_val;
+                for (int i = 0; i < 3; ++i) {
+                  a_val(i) =
+                      symbolic::get_constant_value(separating_plane_sol.a(i));
+                }
+                EXPECT_LE(a_val.norm(), 1 + 1e-6);
+                break;
+              }
+              default: {
+                throw std::runtime_error("Not implemented yet.");
+              }
+            }
+            break;
+          }
+          default: {
+            throw std::runtime_error("Not implemented yet.");
+          }
+        }
+      }
       active_plane_count++;
     }
   }
   EXPECT_EQ(separating_planes_sol.size(), active_plane_count);
 }
 
-TEST_F(IiwaCspaceTest, FindLagrangianAndSeparatingPlanes) {
-  // Test both the single-thread version and the multiple-thread version. Make
-  // sure the result are correct.
-  ApplyFilter();
-  const CspaceFreeRegion dut(*diagram_, plant_, scene_graph_,
+// Test both the single-thread version and the multiple-thread version. Make
+// sure the result are correct.
+void TestFindLagrangianAndSeparatingPlanes(
+    const systems::Diagram<double>& diagram,
+    const MultibodyPlant<double>& plant,
+    const geometry::SceneGraph<double>& scene_graph) {
+  const CspaceFreeRegion dut(diagram, &plant, &scene_graph,
                              SeparatingPlaneOrder::kAffine,
                              CspaceRegionType::kGenericPolytope);
-  const auto& plant = dut.rational_forward_kinematics().plant();
   auto context = plant.CreateDefaultContext();
 
   Eigen::VectorXd q_star;
   Eigen::MatrixXd C;
   Eigen::VectorXd d;
   Eigen::VectorXd q_not_in_collision;
-  ConstructInitialCspacePolytope(dut, &q_star, &C, &d, &q_not_in_collision);
+  ConstructInitialCspacePolytope(dut, diagram, &q_star, &C, &d,
+                                 &q_not_in_collision);
 
   CspaceFreeRegion::FilteredCollisionPairs filtered_collision_pairs{
       {SortedPair<geometry::GeometryId>(
-          dut.separating_planes()[0].positive_side_polytope->get_id(),
-          dut.separating_planes()[0].negative_side_polytope->get_id())}};
+          dut.separating_planes()[0].positive_side_geometry->id(),
+          dut.separating_planes()[0].negative_side_geometry->id())}};
   std::vector<CspaceFreeRegion::CspacePolytopeTuple> alternation_tuples;
   VectorX<symbolic::Polynomial> d_minus_Ct;
   Eigen::VectorXd t_lower, t_upper;
@@ -1040,11 +1537,14 @@ TEST_F(IiwaCspaceTest, FindLagrangianAndSeparatingPlanes) {
   VectorX<symbolic::Variable> d_var, lagrangian_gram_vars, verified_gram_vars,
       separating_plane_vars;
   std::vector<std::vector<int>> separating_plane_to_tuples;
+  std::vector<std::vector<solvers::Binding<solvers::LorentzConeConstraint>>>
+      separating_plane_to_lorentz_cone_constraints;
   dut.GenerateTuplesForBilinearAlternation(
       q_star, filtered_collision_pairs, C.rows(), &alternation_tuples,
       &d_minus_Ct, &t_lower, &t_upper, &t_minus_t_lower, &t_upper_minus_t,
       &C_var, &d_var, &lagrangian_gram_vars, &verified_gram_vars,
-      &separating_plane_vars, &separating_plane_to_tuples);
+      &separating_plane_vars, &separating_plane_to_tuples,
+      &separating_plane_to_lorentz_cone_constraints);
   const std::vector<bool> is_plane_active = internal::IsPlaneActive(
       dut.separating_planes(), filtered_collision_pairs);
   EXPECT_FALSE(is_plane_active[0]);
@@ -1065,11 +1565,11 @@ TEST_F(IiwaCspaceTest, FindLagrangianAndSeparatingPlanes) {
     const bool verbose{true};
     bool is_success = internal::FindLagrangianAndSeparatingPlanes(
         dut, alternation_tuples, C, d, lagrangian_gram_vars, verified_gram_vars,
-        separating_plane_vars, t_lower, t_upper, verification_option,
-        redundant_tighten, solver_options, verbose, num_threads,
-        separating_plane_to_tuples, &lagrangian_gram_var_vals,
-        &verified_gram_var_vals, &separating_plane_var_vals,
-        &cspace_free_region_solution);
+        separating_plane_vars, separating_plane_to_lorentz_cone_constraints,
+        t_lower, t_upper, verification_option, redundant_tighten,
+        solver_options, verbose, num_threads, separating_plane_to_tuples,
+        &lagrangian_gram_var_vals, &verified_gram_var_vals,
+        &separating_plane_var_vals, &cspace_free_region_solution);
     EXPECT_TRUE(is_success);
     EXPECT_EQ(cspace_free_region_solution.separating_planes.size(),
               num_active_planes);
@@ -1084,13 +1584,22 @@ TEST_F(IiwaCspaceTest, FindLagrangianAndSeparatingPlanes) {
     const Eigen::VectorXd d_infeasible = (d.array() + 1E5).matrix();
     is_success = internal::FindLagrangianAndSeparatingPlanes(
         dut, alternation_tuples, C, d_infeasible, lagrangian_gram_vars,
-        verified_gram_vars, separating_plane_vars, t_lower, t_upper,
+        verified_gram_vars, separating_plane_vars,
+        separating_plane_to_lorentz_cone_constraints, t_lower, t_upper,
         verification_option, redundant_tighten, solver_options, verbose,
         num_threads, separating_plane_to_tuples, &lagrangian_gram_var_vals,
         &verified_gram_var_vals, &separating_plane_var_vals,
         &cspace_free_region_solution);
     EXPECT_FALSE(is_success);
   }
+}
+
+TEST_F(IiwaCspaceTest, FindLagrangianAndSeparatingPlanes) {
+  TestFindLagrangianAndSeparatingPlanes(*diagram_, *plant_, *scene_graph_);
+}
+
+TEST_F(IiwaNonpolytopeCollisionCspaceTest, FindLagrangianAndSeparatingPlanes) {
+  TestFindLagrangianAndSeparatingPlanes(*diagram_, *plant_, *scene_graph_);
 }
 
 GTEST_TEST(CalcPolynomialFromGram, Test1) {
@@ -1298,7 +1807,23 @@ GTEST_TEST(AddOuterPolytope, Test) {
   }
 }
 
-GTEST_TEST(GetConvexPolytopes, Test) {
+void CheckVertices(const Eigen::Ref<const Eigen::Matrix3Xd>& vert1,
+                   const Eigen::Ref<const Eigen::Matrix3Xd>& vert2,
+                   double tol) {
+  EXPECT_EQ(vert1.cols(), vert2.cols());
+  for (int i = 0; i < vert1.cols(); ++i) {
+    bool found_match = false;
+    for (int j = 0; j < vert2.cols(); ++j) {
+      if (CompareMatrices(vert1.col(i), vert2.col(j), tol)) {
+        found_match = true;
+        break;
+      }
+    }
+    EXPECT_TRUE(found_match);
+  }
+}
+
+GTEST_TEST(GetCollisionGeometry, Test) {
   systems::DiagramBuilder<double> builder;
   auto iiwa = builder.AddSystem<MultibodyPlant<double>>(
       ConstructIiwaPlant("iiwa14_no_collision.sdf", false));
@@ -1322,49 +1847,122 @@ GTEST_TEST(GetConvexPolytopes, Test) {
       iiwa->GetBodyByName("iiwa_link_7"), X_7P2,
       geometry::Box(box2_size(0), box2_size(1), box2_size(2)), "link7_box2",
       CoulombFriction<double>());
+  const math::RigidTransformd X_5O(Eigen::Vector3d(0.2, 0.3, 0.4));
+  const auto link5_octahedron_id = iiwa->RegisterCollisionGeometry(
+      iiwa->GetBodyByName("iiwa_link_5"), X_5O,
+      geometry::Convex(
+          FindResourceOrThrow("drake/geometry/test/octahedron.obj")),
+      "link5_octahedron", CoulombFriction<double>());
+
+  const math::RigidTransformd X_4S(
+      math::RotationMatrixd(
+          Eigen::AngleAxisd(0.2, Eigen::Vector3d(0.1, 0.3, 0.5).normalized())),
+      Eigen::Vector3d(0.1, 0.5, -0.2));
+  const double link4_sphere_radius{0.2};
+  const auto link4_sphere_id = iiwa->RegisterCollisionGeometry(
+      iiwa->GetBodyByName("iiwa_link_4"), X_4S,
+      geometry::Sphere(link4_sphere_radius), "link4_sphere",
+      CoulombFriction<double>());
 
   const auto world_box_id = iiwa->RegisterCollisionGeometry(
       iiwa->world_body(), {}, geometry::Box(0.2, 0.1, 0.3), "world_box",
       CoulombFriction<double>());
+
+  const math::RigidTransformd X_1Capsule(
+      math::RotationMatrixd(
+          Eigen::AngleAxisd(0.2, Eigen::Vector3d(1. / 3, 2. / 3, 2. / 3))),
+      Eigen::Vector3d(0.2, 0.3, 0.5));
+  const double link1_capsule_radius = 0.2;
+  const double link1_capsule_length = 0.5;
+  const auto link1_capsule_id = iiwa->RegisterCollisionGeometry(
+      iiwa->GetBodyByName("iiwa_link_1"), X_1Capsule,
+      geometry::Capsule(link1_capsule_radius, link1_capsule_length),
+      "link1_capsule", CoulombFriction<double>());
+
   iiwa->Finalize();
   auto diagram = builder.Build();
 
-  const auto polytope_geometries = GetConvexPolytopes(*diagram, iiwa, sg);
-  EXPECT_EQ(polytope_geometries.size(), 2u);
-  const auto& link7_polytopes =
-      polytope_geometries.at(iiwa->GetBodyByName("iiwa_link_7").index());
-  EXPECT_EQ(link7_polytopes.size(), 2u);
-  const auto& obstacles = polytope_geometries.at(iiwa->world_body().index());
-  EXPECT_EQ(obstacles[0].body_index(), iiwa->world_body().index());
-  EXPECT_EQ(obstacles[0].get_id(), world_box_id);
+  const auto collision_geometries = GetCollisionGeometries(*diagram, iiwa, sg);
+  EXPECT_EQ(collision_geometries.size(), 5u);
+  const auto& link7_geometries =
+      collision_geometries.at(iiwa->GetBodyByName("iiwa_link_7").index());
+  EXPECT_EQ(link7_geometries.size(), 2u);
+  const auto& obstacles = collision_geometries.at(iiwa->world_body().index());
+  EXPECT_EQ(obstacles[0]->body_index(), iiwa->world_body().index());
+  EXPECT_EQ(obstacles[0]->id(), world_box_id);
 
-  std::unordered_map<ConvexGeometry::Id, const ConvexPolytope*>
-      link7_polytope_map;
-  for (const auto& link7_polytope : link7_polytopes) {
-    link7_polytope_map.emplace(link7_polytope.get_id(), &link7_polytope);
+  std::unordered_map<geometry::GeometryId, const CollisionGeometry*>
+      link7_geometry_map;
+  for (const auto& link7_geometry : link7_geometries) {
+    link7_geometry_map.emplace(link7_geometry->id(), link7_geometry.get());
   }
-  EXPECT_EQ(link7_polytope_map.size(), 2u);
-  const ConvexPolytope* link7_box1 = link7_polytope_map.at(link7_box1_id);
-  const ConvexPolytope* link7_box2 = link7_polytope_map.at(link7_box2_id);
-  EXPECT_EQ(link7_box1->body_index(),
+  EXPECT_EQ(link7_geometry_map.size(), 2u);
+  const CollisionGeometry* link7_geometry1 =
+      link7_geometry_map.at(link7_box1_id);
+  const CollisionGeometry* link7_geometry2 =
+      link7_geometry_map.at(link7_box2_id);
+  EXPECT_EQ(link7_geometry1->type(), CollisionGeometryType::kPolytope);
+  EXPECT_EQ(link7_geometry2->type(), CollisionGeometryType::kPolytope);
+  EXPECT_EQ(link7_geometry1->body_index(),
             iiwa->GetBodyByName("iiwa_link_7").index());
-  EXPECT_EQ(link7_box2->body_index(),
+  EXPECT_EQ(link7_geometry2->body_index(),
             iiwa->GetBodyByName("iiwa_link_7").index());
   // Now compute the geometry vertices manually and check with
   // link7_box1->p_BV().
   const Eigen::Matrix<double, 3, 8> link7_box2_vertices =
       GenerateBoxVertices(box2_size, X_7P2);
-  EXPECT_EQ(link7_box2->p_BV().cols(), 8);
-  for (int i = 0; i < 8; ++i) {
-    bool found_match = false;
-    for (int j = 0; j < 8; ++j) {
-      if ((link7_box2->p_BV().col(i) - link7_box2_vertices.col(j)).norm() <
-          1E-8) {
-        found_match = true;
-      }
-    }
-    EXPECT_TRUE(found_match);
-  }
+  CheckVertices(
+      link7_geometry2->X_BG() * GetVertices(link7_geometry2->geometry()),
+      link7_box2_vertices, 1E-8);
+
+  // Check the geometry of link5_octahedron.
+  const BodyIndex link5_index = iiwa->GetBodyByName("iiwa_link_5").index();
+  EXPECT_GT(collision_geometries.count(link5_index), 0);
+  EXPECT_EQ(collision_geometries.at(link5_index).size(), 1u);
+  const auto& link5_octahedron = collision_geometries.at(link5_index)[0];
+  EXPECT_EQ(link5_octahedron->body_index(), link5_index);
+  EXPECT_EQ(link5_octahedron->id(), link5_octahedron_id);
+  EXPECT_EQ(link5_octahedron->type(), CollisionGeometryType::kPolytope);
+  Eigen::Matrix<double, 3, 6> link5_octahedron_vertices;
+  // clang-format off
+  link5_octahedron_vertices << 1, 1, -1, -1, 0, 0,
+                               -1, 1, -1, 1, 0, 0,
+                               0, 0, 0, 0, std::sqrt(2), -std::sqrt(2);
+  // clang-format on
+  link5_octahedron_vertices = X_5O * link5_octahedron_vertices;
+  CheckVertices(
+      link5_octahedron->X_BG() * GetVertices(link5_octahedron->geometry()),
+      link5_octahedron_vertices, 1E-8);
+
+  // Check link 4 sphere.
+  const BodyIndex link4_index = iiwa->GetBodyByName("iiwa_link_4").index();
+  EXPECT_GT(collision_geometries.count(link4_index), 0);
+  EXPECT_EQ(collision_geometries.at(link4_index).size(), 1u);
+  const auto& link4_sphere = collision_geometries.at(link4_index)[0];
+  EXPECT_EQ(link4_sphere->type(), CollisionGeometryType::kSphere);
+  EXPECT_EQ(link4_sphere->body_index(), link4_index);
+  EXPECT_EQ(link4_sphere->id(), link4_sphere_id);
+  auto link4_sphere_geometry =
+      dynamic_cast<const geometry::Sphere*>(&link4_sphere->geometry());
+  const double tol{1E-10};
+  EXPECT_EQ(link4_sphere_geometry->radius(), link4_sphere_radius);
+  EXPECT_TRUE(CompareMatrices(link4_sphere->X_BG().translation(),
+                              X_4S.translation(), tol));
+
+  // Check link 1 capsule.
+  const BodyIndex link1_index = iiwa->GetBodyByName("iiwa_link_1").index();
+  EXPECT_GT(collision_geometries.count(link1_index), 0);
+  EXPECT_EQ(collision_geometries.at(link1_index).size(), 1u);
+  const auto& link1_capsule = collision_geometries.at(link1_index)[0];
+  EXPECT_EQ(link1_capsule->type(), CollisionGeometryType::kCapsule);
+  EXPECT_EQ(link1_capsule->body_index(), link1_index);
+  EXPECT_EQ(link1_capsule->id(), link1_capsule_id);
+  auto link1_capsule_geometry =
+      dynamic_cast<const geometry::Capsule*>(&link1_capsule->geometry());
+  EXPECT_EQ(link1_capsule_geometry->radius(), link1_capsule_radius);
+  EXPECT_EQ(link1_capsule_geometry->length(), link1_capsule_length);
+  EXPECT_TRUE(CompareMatrices(link1_capsule->X_BG().GetAsMatrix4(),
+                              X_1Capsule.GetAsMatrix4(), tol));
 }
 
 GTEST_TEST(FindRedundantInequalities, Test) {
@@ -1545,6 +2143,25 @@ GTEST_TEST(AddCspacePolytopeContainment, Test2) {
     EXPECT_TRUE(
         ((C_sol * inner_pts.col(i)).array() <= d_sol.array() + 1E-6).all());
   }
+}
+
+GTEST_TEST(ReadAndWriteCspacePolytopeFile, Test) {
+  Eigen::Matrix<double, 2, 3> C;
+  C << 1.0, -0.000001, 0.5, -0.2, 5E3, 0.001;
+  Eigen::Vector2d d(1, 100000000000);
+  Eigen::Vector3d t_lower(1, -0.005, 10000);
+  Eigen::Vector3d t_upper(1000, 1E-8, 100000);
+  const std::string file_name = temp_directory() + "/cspace_polytope.txt";
+  WriteCspacePolytopeToFile(C, d, t_lower, t_upper, file_name, 10);
+  Eigen::MatrixXd C_read;
+  Eigen::VectorXd d_read, t_lower_read, t_upper_read;
+  ReadCspacePolytopeFromFile(file_name, &C_read, &d_read, &t_lower_read,
+                             &t_upper_read);
+  const double tol = 1E-9;
+  EXPECT_TRUE(CompareMatrices(C, C_read, tol));
+  EXPECT_TRUE(CompareMatrices(d, d_read, tol));
+  EXPECT_TRUE(CompareMatrices(t_lower, t_lower_read, tol));
+  EXPECT_TRUE(CompareMatrices(t_upper, t_upper_read, tol));
 }
 
 }  // namespace multibody

--- a/multibody/rational_forward_kinematics/test/iiwa_shelf_demo.cc
+++ b/multibody/rational_forward_kinematics/test/iiwa_shelf_demo.cc
@@ -1,13 +1,16 @@
 #include <iostream>
+#include <limits>
 
 #include "drake/common/find_resource.h"
 #include "drake/geometry/collision_filter_declaration.h"
 #include "drake/geometry/meshcat_visualizer.h"
+#include "drake/geometry/meshcat_visualizer_params.h"
 #include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/geometry/optimization/polytope_cover.h"
 #include "drake/multibody/inverse_kinematics/inverse_kinematics.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/rational_forward_kinematics/cspace_free_region.h"
+#include "drake/multibody/rational_forward_kinematics/rational_forward_kinematics.h"
 #include "drake/solvers/common_solver_option.h"
 #include "drake/solvers/gurobi_solver.h"
 #include "drake/solvers/mosek_solver.h"
@@ -16,6 +19,8 @@
 
 namespace drake {
 namespace multibody {
+const double kInf = std::numeric_limits<double>::infinity();
+
 class IiwaDiagram {
  public:
   IiwaDiagram() : meshcat_{std::make_shared<geometry::Meshcat>()} {
@@ -72,10 +77,10 @@ class IiwaDiagram {
         geometry::CollisionFilterDeclaration().ExcludeWithin(
             gripper_link6_geometries));
 
-    // Ignore collision between IIWA links.
+    // SceneGraph should ignore collision on the IIWA.
     std::vector<geometry::GeometryId> iiwa_geometry_ids;
     for (const auto& body_index : plant_->GetBodyIndices(iiwa_instance)) {
-      const std::vector<geometry::GeometryId> body_geometry_ids =
+      const auto body_geometry_ids =
           plant_->GetCollisionGeometriesForBody(plant_->get_body(body_index));
       iiwa_geometry_ids.insert(iiwa_geometry_ids.end(),
                                body_geometry_ids.begin(),
@@ -93,6 +98,20 @@ class IiwaDiagram {
         plant_->GetFrameByName("shelves_body", shelf_instance);
     const math::RigidTransformd X_WShelf(Eigen::Vector3d(0.8, 0, 0.4));
     plant_->WeldFrames(plant_->world_frame(), shelf_frame, X_WShelf);
+
+    // Add a sphere as an obstacle.
+    math::RigidTransformd X_WSphere = X_WShelf;
+    X_WSphere.set_translation(X_WShelf.translation() +
+                              Eigen::Vector3d(-0.2, 0.3, 0.1));
+    plant_->RegisterCollisionGeometry(plant_->world_body(), X_WSphere,
+                                      geometry::Sphere(0.1), "world_sphere",
+                                      CoulombFriction<double>());
+
+    // Add a capsule as an obstacle.
+    math::RigidTransformd X_WCapsule(Eigen::Vector3d(0.5, -0.3, 0.3));
+    plant_->RegisterCollisionGeometry(
+        plant_->world_body(), X_WCapsule, geometry::Capsule(0.03, 0.4),
+        "world_capsule", CoulombFriction<double>());
 
     plant_->Finalize();
 
@@ -125,8 +144,8 @@ Eigen::VectorXd FindInitialPosture(const MultibodyPlant<double>& plant,
   const auto& link7 = plant.GetFrameByName("iiwa_link_7");
   const auto& shelf = plant.GetFrameByName("shelves_body");
   ik.AddPositionConstraint(link7, Eigen::Vector3d::Zero(), shelf,
-                           Eigen::Vector3d(-0.4, -0.2, -0.2),
-                           Eigen::Vector3d(-.1, 0.2, 0.2));
+                           Eigen::Vector3d(-0.25, -0.2, -0.2),
+                           Eigen::Vector3d(-.0, 0.2, 0.2));
   ik.AddMinimumDistanceConstraint(0.02);
 
   Eigen::Matrix<double, 7, 1> q_init;
@@ -172,14 +191,13 @@ void BuildCandidateCspacePolytope(const Eigen::VectorXd q_free,
   for (int i = 0; i < C_rows; ++i) {
     C->row(i).normalize();
   }
-  *d = (*C) * (q_free / 2).array().tan().matrix() +
-       0.0001 * Eigen::VectorXd::Ones(C_rows);
+  *d = (*C) * (q_free / 2).array().tan().matrix();
   if (!geometry::optimization::HPolyhedron(*C, *d).IsBounded()) {
     throw std::runtime_error("C*t <= d is not bounded");
   }
 }
 
-int DoMain() {
+void SearchCspacePolytope(const std::string& write_file) {
   // Ensure that we have the MOSEK license for the entire duration of this test,
   // so that we do not have to release and re-acquire the license for every
   // test.
@@ -196,16 +214,17 @@ int DoMain() {
   Eigen::VectorXd d_init;
   BuildCandidateCspacePolytope(q0, &C_init, &d_init);
 
-  const CspaceFreeRegion dut(iiwa_diagram.diagram(), &(iiwa_diagram.plant()),
-                             &(iiwa_diagram.scene_graph()),
-                             SeparatingPlaneOrder::kAffine,
-                             CspaceRegionType::kGenericPolytope);
+  const double separating_polytope_delta{0.001};
+  const CspaceFreeRegion dut(
+      iiwa_diagram.diagram(), &(iiwa_diagram.plant()),
+      &(iiwa_diagram.scene_graph()), SeparatingPlaneOrder::kAffine,
+      CspaceRegionType::kGenericPolytope, separating_polytope_delta);
 
   CspaceFreeRegion::FilteredCollisionPairs filtered_collision_pairs{};
 
   CspaceFreeRegion::BinarySearchOption binary_search_option{
       .epsilon_max = 0.01,
-      .epsilon_min = 0.,
+      .epsilon_min = 1E-6,
       .max_iters = 2,
       .compute_polytope_volume = false,
       .num_threads = -1};
@@ -218,7 +237,7 @@ int DoMain() {
       solver_options, q0, std::nullopt, &cspace_free_region_solution);
   CspaceFreeRegion::BilinearAlternationOption bilinear_alternation_option{
       .max_iters = 10,
-      .convergence_tol = 0.001,
+      .convergence_tol = 0.000,
       .lagrangian_backoff_scale = 0.01,
       .redundant_tighten = 0.5,
       .compute_polytope_volume = false,
@@ -234,8 +253,62 @@ int DoMain() {
   Eigen::VectorXd q_final(cspace_free_region_solution.q);
 
   // Compute the determinant of the final polytope.
-  drake::log()->info("det(P) {}", P_final.determinant());
+  drake::log()->info("det(P) {}", cspace_free_region_solution.P.determinant());
+  const Eigen::VectorXd t_upper =
+      (iiwa_diagram.plant().GetPositionUpperLimits() / 2)
+          .array()
+          .tan()
+          .matrix();
+  const Eigen::VectorXd t_lower =
+      (iiwa_diagram.plant().GetPositionLowerLimits() / 2)
+          .array()
+          .tan()
+          .matrix();
+  WriteCspacePolytopeToFile(cspace_free_region_solution.C,
+                            cspace_free_region_solution.d, t_lower, t_upper,
+                            write_file, 10);
+}
 
+void VisualizePostures(const std::string& cspace_polytope_file,
+                       int num_postures) {
+  IiwaDiagram iiwa_diagram{};
+  auto diagram_context = iiwa_diagram.diagram().CreateDefaultContext();
+  auto& plant_context =
+      iiwa_diagram.plant().GetMyMutableContextFromRoot(diagram_context.get());
+  Eigen::MatrixXd C;
+  Eigen::VectorXd d, t_lower, t_upper;
+  ReadCspacePolytopeFromFile(cspace_polytope_file, &C, &d, &t_lower, &t_upper);
+  const int nt = t_lower.rows();
+
+  Eigen::MatrixXd t_samples = Eigen::MatrixXd::Random(nt, num_postures);
+  // Project t_samples.col(i) to the polytope.
+  solvers::MathematicalProgram prog;
+  auto t_project = prog.NewContinuousVariables(nt);
+  prog.AddBoundingBoxConstraint(t_lower, t_upper, t_project);
+  prog.AddLinearConstraint(C, Eigen::VectorXd::Constant(d.rows(), -kInf), d,
+                           t_project);
+  auto cost = prog.AddQuadraticErrorCost(Eigen::MatrixXd::Identity(nt, nt),
+                                         Eigen::VectorXd::Zero(nt), t_project);
+  for (int i = 0; i < num_postures; ++i) {
+    t_samples.col(i) =
+        (t_samples.col(i).array() * (t_upper - t_lower).array() / 2).matrix() +
+        (t_upper + t_lower) / 2;
+    cost.evaluator()->UpdateCoefficients(Eigen::MatrixXd::Identity(nt, nt),
+                                         -t_samples.col(i), 0.);
+    const auto result = solvers::Solve(prog);
+    DRAKE_DEMAND(result.is_success());
+    const auto t_val = result.GetSolution(t_project);
+    const Eigen::VectorXd q_val = (t_val.array().atan() * 2).matrix();
+    iiwa_diagram.plant().SetPositions(&plant_context, q_val);
+    iiwa_diagram.diagram().Publish(*diagram_context);
+    std::cin.get();
+  }
+}
+
+int DoMain() {
+  const std::string cspace_polytope_file = "iiwa_shelf_cspace_polytope.txt";
+  SearchCspacePolytope(cspace_polytope_file);
+  VisualizePostures(cspace_polytope_file, 10);
   return 0;
 }
 }  // namespace multibody


### PR DESCRIPTION
Currently the order of the separating plane has to be kConstant if either or both collision geometries are non-polytopic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alexandreamice/drake/23)
<!-- Reviewable:end -->
