### PR TITLE
Clean GetBezierExpression implementation

### DIFF
--- a/common/trajectories/BUILD.bazel
+++ b/common/trajectories/BUILD.bazel
@@ -153,6 +153,8 @@ drake_cc_library(
     ],
     deps = [
         ":trajectory",
+        "//common:drake_bool",
+        "//common/symbolic:polynomial",
         "//math:binomial_coefficient",
     ],
 )

--- a/common/trajectories/bezier_curve.h
+++ b/common/trajectories/bezier_curve.h
@@ -66,17 +66,10 @@ class BezierCurve final : public trajectories::Trajectory<T> {
            a trajectory defined over [0, 1]. */
   MatrixX<T> value(const T& time) const override;
 
-  MatrixX<symbolic::Expression> GetBezierExpression(
+  /** Extracts the underlying polynomial expression of this curve in terms of
+   variable `time`. */
+  MatrixX<symbolic::Expression> GetExpression(
       symbolic::Variable time = symbolic::Variable("t")) const;
-
-  /** Evaluates the curve at the given time. If clamp_time is true and t does
-   not lie in the range [start_time(), end_time()], the trajectory will silently
-   be evaluated at the closest valid value of time to `time`. For example,
-   `value(-1)` will return `value(0)` for a trajectory defined over [0, 1]. When
-   the curve is of type Expression, calling this method with time =
-   symbolic::Variable("t") and clamp_time = false enables the extraction of the
-   underlying polynomial expression of this curve. */
-  MatrixX<T> value(const T& time, bool clamp_time) const;
 
   Eigen::Index rows() const override { return control_points_.rows(); }
 
@@ -96,7 +89,6 @@ class BezierCurve final : public trajectories::Trajectory<T> {
   std::unique_ptr<trajectories::Trajectory<T>> DoMakeDerivative(
       int derivative_order) const override;
 
-  template <typename T>
   MatrixX<T> EvaluateT(const T& time) const;
 
   double start_time_{};

--- a/common/trajectories/test/bezier_curve_test.cc
+++ b/common/trajectories/test/bezier_curve_test.cc
@@ -26,17 +26,14 @@ GTEST_TEST(BezierCurveTest, Linear) {
   EXPECT_TRUE(
       CompareMatrices(curve.value(2.5), Eigen::Vector2d(1.5, 5), 1e-14));
   EXPECT_TRUE(
-      CompareMatrices(curve.value(0, true), Eigen::Vector2d(1, 3), 1e-14));
-  EXPECT_TRUE(
-      CompareMatrices(curve.value(0, false), Eigen::Vector2d(-1, -5), 1e-14));
+      CompareMatrices(curve.value(0), Eigen::Vector2d(1, 3), 1e-14));
 
-  BezierCurve<symbolic::Expression> curve_sym(
-      2, 3, points.cast<symbolic::Expression>());
-  VectorX<symbolic::Expression> curve_sym_expression{
-      curve_sym.value(symbolic::Variable("t"), false)};
-  for (int i = 0; i < curve_sym_expression.rows(); i++) {
-    EXPECT_TRUE(curve_sym_expression(i).is_polynomial());
-    EXPECT_EQ(symbolic::Polynomial(curve_sym_expression(i)).TotalDegree(), 1);
+  // Extract the symoblic exprssion for the bezier curve.
+  const VectorX<symbolic::Expression> curve_expression{
+      curve.GetExpression(symbolic::Variable("t"))};
+  for (int i = 0; i < curve_expression.rows(); i++) {
+    EXPECT_TRUE(curve_expression(i).is_polynomial());
+    EXPECT_EQ(symbolic::Polynomial(curve_expression(i)).TotalDegree(), 1);
   }
 
   auto deriv = curve.MakeDerivative();
@@ -93,14 +90,10 @@ GTEST_TEST(BezierCurveTest, Quadratic) {
     EXPECT_TRUE(CompareMatrices(curve.value(sample_time),
                                 Eigen::Vector2d((1 - t) * (1 - t), t * t),
                                 1e-14));
-    EXPECT_TRUE(CompareMatrices(curve.value(sample_time, true),
+    EXPECT_TRUE(CompareMatrices(curve.value(sample_time),
                                 Eigen::Vector2d((1 - t) * (1 - t), t * t),
                                 1e-14));
-    EXPECT_TRUE(
-        CompareMatrices(curve.value(sample_time, false),
-                        Eigen::Vector2d((1 - sample_time) * (1 - sample_time),
-                                        sample_time * sample_time),
-                        1e-14));
+
     EXPECT_TRUE(CompareMatrices(deriv->value(sample_time),
                                 Eigen::Vector2d(-2 * (1 - t), 2 * t), 1e-14));
     EXPECT_TRUE(CompareMatrices(curve.EvalDerivative(sample_time),
@@ -110,13 +103,13 @@ GTEST_TEST(BezierCurveTest, Quadratic) {
     EXPECT_TRUE(CompareMatrices(curve.EvalDerivative(sample_time, 2),
                                 Eigen::Vector2d(2, 2), 1e-14));
   }
-  BezierCurve<symbolic::Expression> curve_sym(
-      2, 3, points.cast<symbolic::Expression>());
-  VectorX<symbolic::Expression> curve_sym_expression{
-      curve_sym.value(symbolic::Variable("t"), false)};
-  for (int i = 0; i < curve_sym_expression.rows(); i++) {
-    EXPECT_TRUE(curve_sym_expression(i).is_polynomial());
-    EXPECT_EQ(symbolic::Polynomial(curve_sym_expression(i)).TotalDegree(), 2);
+  
+  // Extract the symoblic exprssion for the bezier curve.
+  VectorX<symbolic::Expression> curve_expression{
+      curve.GetExpression(symbolic::Variable("t"))};
+  for (int i = 0; i < curve_expression.rows(); i++) {
+    EXPECT_TRUE(curve_expression(i).is_polynomial());
+    EXPECT_EQ(symbolic::Polynomial(curve_expression(i)).TotalDegree(), 2);
   }
 }
 


### PR DESCRIPTION
- Simplifies the implementation of (what was formerly known as) GetBezierExpression using convenient `if consexpr`.
- Strips out the tenatative "unclamped value" declaration.
- Cleans up declaration of EvaluateT.
- An attempt to clean up the tests.

TODO:
 1. While GetBezierExpression seemed redundant (BezierCurve::GetBezierExpression), simply GetExpression may be too terse. Feel free to rename it.
 2. Add missing testing
    - It would be good to have at least one test that actually confirms the expression is what we think.
    - The test currently only extracts the expression from a T = double curve. Extend the test(s) to include T = AutoDiffXd and T = Exprssion.
    - Test using the default-valued `time` parameter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AlexandreAmice/drake/70)
<!-- Reviewable:end -->
