### PR TITLE
solvers: allow explicit solver in Solve API

### DIFF
--- a/ISSUE_20681_PLAN.md
+++ b/ISSUE_20681_PLAN.md
@@ -1,0 +1,64 @@
+# ISSUE 20681 Plan - Add optional solver argument to `solvers::Solve()`
+
+Issue: https://github.com/RobotLocomotion/drake/issues/20681
+
+## Objective
+
+Add a first-class API path for callers to provide an explicit solver instance when invoking top-level `solvers::Solve`, eliminating repeated `if (solver != nullptr) { ... } else { ... }` logic in downstream wrappers.
+
+## Scope
+
+- In scope:
+  - Add a new overload (or signature extension) for `solvers::Solve` that accepts `const SolverInterface*`.
+  - Preserve existing behavior when no solver is provided (`ChooseBestSolver` path).
+  - Add unit tests proving explicit solver usage and no-regression behavior.
+  - Keep API and docs coherent in `solve.h`.
+- Out of scope:
+  - Broad API propagation across all wrappers (IK, IRIS, Toppra, etc.) in this issue branch.
+  - Changes to `SolveInParallel` solver-id APIs.
+
+## Constraints and design decisions
+
+- Must support out-of-tree solvers, so API accepts `const SolverInterface*` (not `SolverId`) per issue discussion.
+- Must remain source-compatible for existing 1/2/3-arg `Solve` call sites.
+- Must keep semantics of option precedence and initial guess unchanged.
+- Must avoid any solver ownership transfer; caller owns the pointer lifetime.
+
+## Implementation plan
+
+1. API update in `solvers/solve.h`.
+   - Extend `Solve(const MathematicalProgram&, optional initial_guess, optional solver_options, const SolverInterface* solver = nullptr)`.
+   - Keep `Solve(prog)` and `Solve(prog, initial_guess)` convenience overloads.
+   - Add doc text for explicit solver semantics.
+2. Behavior update in `solvers/solve.cc`.
+   - If `solver != nullptr`, call that solver directly.
+   - Else keep existing `ChooseBestSolver` + `MakeSolver` flow.
+   - Preserve debug log message with the actual solver id used.
+3. Tests in `solvers/test/solve_test.cc`.
+   - Add a test that passes a known available solver (`LinearSystemSolver`) explicitly and validates solution + solver id.
+   - Keep no-regression checks for existing call patterns.
+4. Build/test gate.
+   - Run `bazel test //solvers/test:solve_test`.
+   - If needed, run targeted related tests for compilation confidence.
+
+## Verification checklist
+
+- [x] New API compiles without ambiguity at current call sites.
+- [x] Explicit solver pointer path is exercised by unit tests.
+- [x] Existing tests continue to pass (`//solvers:solve_test`).
+- [x] No in-tree C++ compile breakage observed for this target.
+
+## Risks and mitigations
+
+- Risk: overload ambiguity with existing signatures.
+  - Mitigation: use a single canonical signature for optional arguments with explicit convenience overloads.
+- Risk: explicit incompatible solver pointer usage fails at runtime.
+  - Mitigation: rely on existing solver-side checks; optionally add throw expectation test if stable.
+
+## Progress log
+
+- 2026-02-19: Created implementation plan with scope, design constraints, and test gates prior to code edits.
+- 2026-02-19: Added local Bazel worktree prerequisites (`gen/environment.bazelrc` symlink and `gen/python_version.txt`) so tests can execute from this worktree.
+- 2026-02-19: Updated `solvers::Solve` API to accept `const SolverInterface* solver` and to use `ChooseBestSolver` only when `solver == nullptr`.
+- 2026-02-19: Added `SolveTest.ExplicitSolverArgument` coverage in `solvers/test/solve_test.cc`.
+- 2026-02-19: Ran `bazel test //solvers:solve_test` and confirmed pass.

--- a/solvers/solve.h
+++ b/solvers/solve.h
@@ -11,12 +11,15 @@
 
 namespace drake {
 namespace solvers {
+class SolverInterface;
+
 /**
  * Solves an optimization program, with optional initial guess and solver
  * options. This function first chooses the best solver depending on the
  * availability of the solver and the program formulation; it then constructs
- * that solver and call the Solve function of that solver. The optimization
- * result is stored in the return argument.
+ * that solver and calls its Solve function. If @p solver is non-null, this
+ * function will use @p solver directly instead of choosing a solver. The
+ * optimization result is stored in the return argument.
  * @param prog Contains the formulation of the program, and possibly solver
  * options.
  * @param initial_guess The initial guess for the decision variables. If an
@@ -30,12 +33,14 @@ namespace solvers {
  * 2. common option passed as an argument to Solve
  * 3. solver-specific option set on the MathematicalProgram itself
  * 4. solver-specific option passed as an argument to Solve
+ * @param solver If non-null, the solver instance to use.
  * @return result The result of solving the program through the solver.
  */
 MathematicalProgramResult Solve(
     const MathematicalProgram& prog,
     const std::optional<Eigen::VectorXd>& initial_guess,
-    const std::optional<SolverOptions>& solver_options);
+    const std::optional<SolverOptions>& solver_options,
+    const SolverInterface* solver = nullptr);
 
 /**
  * Solves an optimization program with a given initial guess.

--- a/solvers/test/solve_test.cc
+++ b/solvers/test/solve_test.cc
@@ -56,5 +56,19 @@ GTEST_TEST(SolveTest, TestInitialGuessAndOptions) {
     EXPECT_NEAR(result.GetSolution(x)(0), vars_init(0), 1E-6);
   }
 }
+
+GTEST_TEST(SolveTest, ExplicitSolverArgument) {
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<2>();
+  prog.AddLinearEqualityConstraint(Eigen::Matrix2d::Identity(),
+                                   Eigen::Vector2d(1, 2), x);
+
+  LinearSystemSolver solver;
+  const auto result = Solve(prog, std::nullopt, std::nullopt, &solver);
+  EXPECT_TRUE(result.is_success());
+  EXPECT_TRUE(
+      CompareMatrices(result.get_x_val(), Eigen::Vector2d(1, 2), 1E-12));
+  EXPECT_EQ(result.get_solver_id(), LinearSystemSolver::id());
+}
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
## Summary
Implements feature request #20681 by allowing callers to pass an explicit `const SolverInterface*` into top-level `solvers::Solve(...)`, while preserving existing automatic solver selection when no solver is provided.

## Changes
- Extend `Solve` API in `solvers/solve.h` with optional `const SolverInterface* solver = nullptr`
- Update implementation in `solvers/solve.cc` to use explicit solver when provided, otherwise fall back to `ChooseBestSolver`
- Add unit test `SolveTest.ExplicitSolverArgument` in `solvers/test/solve_test.cc`
- Add detailed execution log and plan in `ISSUE_20681_PLAN.md`

## Testing
- `bazel test //solvers:solve_test`

## Issue
- https://github.com/RobotLocomotion/drake/issues/20681

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AlexandreAmice/drake/88)
<!-- Reviewable:end -->
