### PR TITLE
schema: add probability density API for distributions

### DIFF
--- a/ISSUE_20451_PLAN.md
+++ b/ISSUE_20451_PLAN.md
@@ -1,0 +1,64 @@
+# ISSUE 20451 Plan - Return sample probability for schema distributions
+
+Issue: https://github.com/RobotLocomotion/drake/issues/20451
+
+## Objective
+
+Add a reusable probability-evaluation API for `schema::Distribution` and `DistributionVariant` so callers can evaluate probability density / mass at a sampled value without per-type branching.
+
+## Scope
+
+- In scope:
+  - Extend scalar distribution classes with probability evaluation method(s).
+  - Add variant-level helper function(s) (similar style to existing `Sample`, `Mean`, `ToSymbolic` helpers).
+  - Add focused tests for all scalar distribution kinds.
+- Out of scope:
+  - Autodiff wrt distribution parameters (current schema types store `double` parameters).
+  - Vector distribution probability APIs (can follow-up).
+  - Python bindings unless required by build breakage.
+
+## Design notes
+
+- Issue discussion suggests "CalcProbabilityDensity available in the base class" as a desired direction.
+- For continuous distributions (`Gaussian`, `Uniform`), evaluate PDF.
+- For discrete distributions (`UniformDiscrete`, deterministic), evaluate PMF-like probability at exact support values.
+- API naming will make this mixed semantics explicit via docs.
+
+## Implementation plan
+
+1. API surface in `common/schema/stochastic.h`.
+   - Add virtual method on `Distribution` for probability-at-value evaluation.
+   - Add free-function helper on `DistributionVariant`.
+2. Implement in `common/schema/stochastic.cc`.
+   - Deterministic: 1 at exact value, otherwise 0.
+   - Gaussian: normal density at `x`.
+   - Uniform: reciprocal interval length within support, else 0.
+   - UniformDiscrete: probability mass across occurrences.
+   - Variant helper delegates through `ToDistribution`.
+3. Tests in `common/schema/test/stochastic_test.cc`.
+   - Add explicit checks for each distribution class.
+   - Validate edge behavior outside support.
+4. Build/test gate.
+   - Run `bazel test //common/schema:test/stochastic_test`.
+
+## Verification checklist
+
+- [x] New API is documented and consistent with existing helper style.
+- [x] Probability values are numerically correct in tests.
+- [x] Existing stochastic tests remain green (`//common/schema:stochastic_test`).
+
+## Risks and mitigations
+
+- Risk: confusion between density vs mass semantics.
+  - Mitigation: explicit docs and class-by-class test assertions.
+- Risk: degenerate parameter values (e.g., zero-width uniform).
+  - Mitigation: define deterministic fallback behavior and test it.
+
+## Progress log
+
+- 2026-02-19: Created implementation plan with scope limits and numerical behavior targets before editing code.
+- 2026-02-19: Added local Bazel worktree prerequisites (`gen/environment.bazelrc` symlink and `gen/python_version.txt`) so tests can execute from this worktree.
+- 2026-02-19: Added `Distribution::CalcProbabilityDensity(double)` and per-type implementations for `Deterministic`, `Gaussian`, `Uniform`, and `UniformDiscrete`.
+- 2026-02-19: Added variant helper `schema::CalcProbabilityDensity(const DistributionVariant&, double)`.
+- 2026-02-19: Extended `common/schema/test/stochastic_test.cc` with scalar and variant-level probability-density assertions.
+- 2026-02-19: Ran `bazel test //common/schema:stochastic_test` and confirmed pass.

--- a/common/schema/stochastic.h
+++ b/common/schema/stochastic.h
@@ -205,6 +205,9 @@ class Distribution {
   virtual ~Distribution();
 
   virtual double Sample(drake::RandomGenerator* generator) const = 0;
+  /// Returns the probability density (for continuous distributions) or
+  /// probability mass (for discrete distributions) at @p value.
+  virtual double CalcProbabilityDensity(double value) const = 0;
   virtual double Mean() const = 0;
   virtual drake::symbolic::Expression ToSymbolic() const = 0;
 
@@ -224,6 +227,7 @@ class Deterministic final : public Distribution {
   ~Deterministic() final;
 
   double Sample(drake::RandomGenerator*) const final;
+  double CalcProbabilityDensity(double value) const final;
   double Mean() const final;
   drake::symbolic::Expression ToSymbolic() const final;
 
@@ -245,6 +249,7 @@ class Gaussian final : public Distribution {
   ~Gaussian() final;
 
   double Sample(drake::RandomGenerator*) const final;
+  double CalcProbabilityDensity(double value) const final;
   double Mean() const final;
   drake::symbolic::Expression ToSymbolic() const final;
 
@@ -268,6 +273,7 @@ class Uniform final : public Distribution {
   ~Uniform() final;
 
   double Sample(drake::RandomGenerator*) const final;
+  double CalcProbabilityDensity(double value) const final;
   double Mean() const final;
   drake::symbolic::Expression ToSymbolic() const final;
 
@@ -291,6 +297,7 @@ class UniformDiscrete final : public Distribution {
   ~UniformDiscrete() final;
 
   double Sample(drake::RandomGenerator*) const final;
+  double CalcProbabilityDensity(double value) const final;
   double Mean() const final;
   drake::symbolic::Expression ToSymbolic() const final;
 
@@ -312,6 +319,10 @@ std::unique_ptr<Distribution> ToDistribution(const DistributionVariant& var);
 /// Like Distribution::Sample, but on a DistributionVariant instead.
 double Sample(const DistributionVariant& var,
               drake::RandomGenerator* generator);
+
+/// Like Distribution::CalcProbabilityDensity, but on a DistributionVariant
+/// instead.
+double CalcProbabilityDensity(const DistributionVariant& var, double value);
 
 /// Like Distribution::Mean, but on a DistributionVariant instead.
 double Mean(const DistributionVariant& var);


### PR DESCRIPTION
## Summary
Implements feature request #20451 by adding a probability-evaluation API to scalar schema distributions and variant helpers.

## Changes
- Add `Distribution::CalcProbabilityDensity(double)` virtual API
- Implement for `Deterministic`, `Gaussian`, `Uniform`, and `UniformDiscrete`
- Add variant helper `CalcProbabilityDensity(const DistributionVariant&, double)`
- Add thorough unit tests in `common/schema/test/stochastic_test.cc` for class-level and variant-level behavior
- Add detailed execution log and plan in `ISSUE_20451_PLAN.md`

## Testing
- `bazel test //common/schema:stochastic_test`

## Issue
- https://github.com/RobotLocomotion/drake/issues/20451

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AlexandreAmice/drake/91)
<!-- Reviewable:end -->
