### PR TITLE
[solvers] Return variable mapping from MakeSemidefiniteRelaxation (#19996)

### DIFF
--- a/ISSUE_19996_PLAN.md
+++ b/ISSUE_19996_PLAN.md
@@ -1,0 +1,57 @@
+# ISSUE #19996 Plan
+
+Issue: https://github.com/RobotLocomotion/drake/issues/19996
+Title: Return variable mapping in MakeSemidefiniteRelaxation
+Owner branch: issue-19996-feature
+Last updated: 2026-02-19 02:42:47 UTC
+Status: Implemented (final Python target run deferred)
+
+## Problem Statement
+`MakeSemidefiniteRelaxation(prog)` returns only the relaxed program, so callers must manually reverse-engineer lifted variable indexing from PSD constraints. This duplicates internal logic and is error-prone.
+
+## Scope Decision
+- In scope:
+- Add a backward-compatible C++ overload that outputs the internal `Variable -> sorted index` map used to place original variables into lifted matrix `X`.
+- Add a Python API that returns `(relaxation, mapping)`.
+- Add C++ and Python unit coverage for mapping correctness.
+- Out of scope:
+- Full monomial mapping utilities.
+- Grouped-relaxation mapping API design.
+
+## Implemented API (MVP)
+1. C++ overload in `solvers/semidefinite_relaxation.h`:
+- `MakeSemidefiniteRelaxation(const MathematicalProgram&, std::map<symbolic::Variable, int>*, const SemidefiniteRelaxationOptions&)`
+2. Existing overload preserved and internally delegated through shared implementation.
+3. Python function in `bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc`:
+- `MakeSemidefiniteRelaxationWithVariableMapping(prog, options=...) -> (relaxation, dict)`
+
+## Success Criteria
+- C++ callers can get deterministic variable index mapping without parsing PSD constraint internals.
+- Mapping aligns with `X(i, end)` placement of original decision variables.
+- Existing `MakeSemidefiniteRelaxation` behavior remains unchanged.
+
+## Implementation Plan
+1. Thread optional map output through semidefinite-relaxation construction internals.
+2. Add public overload in header / source.
+3. Add Python tuple-returning helper.
+4. Add tests:
+- `solvers/test/semidefinite_relaxation_test.cc`
+- `bindings/pydrake/solvers/test/semidefinite_relaxation_test.py`
+5. Run targeted tests.
+
+## Test Plan
+- C++: `bazel test //solvers:semidefinite_relaxation_test --test_output=errors`
+- Python: `bazel test //bindings/pydrake/solvers:py/semidefinite_relaxation_test --test_output=errors`
+
+## Risks / Open Questions
+- Python target has heavy transitive build cost; may require dedicated run window in low-contention environment.
+
+## Execution Log
+- 2026-02-19 00:00:00 UTC: Created initial plan.
+- 2026-02-19 02:31:00 UTC: Added overload declaration and docs in `solvers/semidefinite_relaxation.h`.
+- 2026-02-19 02:32:00 UTC: Implemented overload plumbing and shared helper in `solvers/semidefinite_relaxation.cc`.
+- 2026-02-19 02:34:00 UTC: Added Python wrapper `MakeSemidefiniteRelaxationWithVariableMapping`.
+- 2026-02-19 02:35:00 UTC: Added C++ mapping test in `solvers/test/semidefinite_relaxation_test.cc`.
+- 2026-02-19 02:35:00 UTC: Added Python mapping test in `bindings/pydrake/solvers/test/semidefinite_relaxation_test.py`.
+- 2026-02-19 02:37:00 UTC: Ran `bazel test //solvers:semidefinite_relaxation_test --test_output=errors` (pass).
+- 2026-02-19 02:38-02:43 UTC: Attempted `bazel test //bindings/pydrake/solvers:py/semidefinite_relaxation_test --test_output=errors`; build was progressing but deferred due long compile time in this session.

--- a/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
+++ b/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
@@ -48,6 +48,21 @@ void DefineSolversSemidefiniteRelaxation(py::module m) {
           &solvers::MakeSemidefiniteRelaxation),
       py::arg("prog"), py::arg("options") = SemidefiniteRelaxationOptions{},
       doc.MakeSemidefiniteRelaxation.doc_2args);
+  m.def(
+      "MakeSemidefiniteRelaxationWithVariableMapping",
+      [](const MathematicalProgram& prog,
+          const SemidefiniteRelaxationOptions& options) {
+        std::map<symbolic::Variable, int> variable_to_sorted_indices;
+        auto relaxation = solvers::MakeSemidefiniteRelaxation(
+            prog, &variable_to_sorted_indices, options);
+        return py::make_tuple(
+            std::move(relaxation), std::move(variable_to_sorted_indices));
+      },
+      py::arg("prog"), py::arg("options") = SemidefiniteRelaxationOptions{},
+      "Constructs a semidefinite relaxation and returns a tuple "
+      "(relaxation, variable_to_sorted_indices), where each index gives the "
+      "row / column position of the corresponding original decision variable "
+      "in the lifted matrix X.");
   m.def("MakeSemidefiniteRelaxation",
       py::overload_cast<const MathematicalProgram&,
           const std::vector<symbolic::Variables>&,

--- a/solvers/semidefinite_relaxation.h
+++ b/solvers/semidefinite_relaxation.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <memory>
 #include <vector>
 
@@ -71,6 +72,24 @@ struct SemidefiniteRelaxationOptions {
  */
 std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
     const MathematicalProgram& prog,
+    const SemidefiniteRelaxationOptions& options = {});
+
+/** Constructs a semidefinite relaxation as in MakeSemidefiniteRelaxation(prog)
+ * and also returns the variable-to-index mapping used in the lifted matrix X.
+ *
+ * Let the sorted original decision variables be y, and let X be the lifted
+ * matrix
+ * X = [Y,    y]
+ *     [yᵀ, one].
+ * Then for each original decision variable v, the mapping gives the index i
+ * such that X(i, X.cols() - 1) == v.
+ *
+ * @param[out] variable_to_sorted_indices Map from original decision variables
+ * to their sorted index in y. Existing contents are overwritten.
+ */
+std::unique_ptr<MathematicalProgram> MakeSemidefiniteRelaxation(
+    const MathematicalProgram& prog,
+    std::map<symbolic::Variable, int>* variable_to_sorted_indices,
     const SemidefiniteRelaxationOptions& options = {});
 
 /** A version of MakeSemidefiniteRelaxation that allows for specifying the


### PR DESCRIPTION
Implements issue #19996 by exposing the variable-to-index mapping already computed during semidefinite relaxation construction.

## What changed
- Added C++ overload:
  - `MakeSemidefiniteRelaxation(const MathematicalProgram&, std::map<symbolic::Variable, int>*, const SemidefiniteRelaxationOptions&)`
- Kept existing overload behavior by delegating through shared implementation.
- Added Python helper:
  - `MakeSemidefiniteRelaxationWithVariableMapping(prog, options=...) -> (relaxation, mapping)`
- Added unit tests:
  - `solvers/test/semidefinite_relaxation_test.cc`
  - `bindings/pydrake/solvers/test/semidefinite_relaxation_test.py`
- Added execution plan / trace file:
  - `ISSUE_19996_PLAN.md`

## Test status
- ✅ `bazel test //solvers:semidefinite_relaxation_test --test_output=errors`
- ⏳ Attempted `bazel test //bindings/pydrake/solvers:py/semidefinite_relaxation_test --test_output=errors`; long compile in this session, so final pass confirmation is pending.

This commit message includes Codex feature implementation attribution per workflow preference.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/AlexandreAmice/drake/95)
<!-- Reviewable:end -->
